### PR TITLE
Fix indicator bar position

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2475,8 +2475,11 @@ int indicatorBarRefresh()
         }
 
         if (count != 0) {
-            gIndicatorBarWindow = windowCreate(0,
-                screenGetHeight() - INTERFACE_BAR_HEIGHT - INDICATOR_BOX_HEIGHT - 1,
+            Rect interfaceBarWindowRect;
+            windowGetRect(gInterfaceBarWindow, &interfaceBarWindowRect);
+
+            gIndicatorBarWindow = windowCreate(interfaceBarWindowRect.left,
+                screenGetHeight() - INTERFACE_BAR_HEIGHT - INDICATOR_BOX_HEIGHT,
                 (INDICATOR_BOX_WIDTH - INDICATOR_BOX_CONNECTOR_WIDTH) * count,
                 INDICATOR_BOX_HEIGHT,
                 _colorTable[0],


### PR DESCRIPTION
Indicator bar will always be attached to the top-left corner of the interface bar like in Sfall.

Closes #6