### PR TITLE
ISO C++ forbids converting a string constant to char*

### DIFF
--- a/src/color.cc
+++ b/src/color.cc
@@ -354,7 +354,7 @@ void _setMixTableColor(int a1)
 }
 
 // 0x4C78E4
-bool colorPaletteLoad(char* path)
+bool colorPaletteLoad(const char* path)
 {
     if (gColorFileNameMangler != NULL) {
         path = gColorFileNameMangler(path);

--- a/src/color.h
+++ b/src/color.h
@@ -5,7 +5,7 @@
 
 #include <stdlib.h>
 
-typedef char*(ColorFileNameManger)(char*);
+typedef const char*(ColorFileNameManger)(const char*);
 typedef void(ColorTransitionCallback)();
 
 typedef int(ColorPaletteFileOpenProc)(const char* path, int mode);
@@ -54,7 +54,7 @@ void _setSystemPaletteEntries(unsigned char* a1, int a2, int a3);
 void _setIntensityTableColor(int a1);
 void _setIntensityTables();
 void _setMixTableColor(int a1);
-bool colorPaletteLoad(char* path);
+bool colorPaletteLoad(const char* path);
 char* _colorError();
 void _buildBlendTable(unsigned char* ptr, unsigned char ch);
 void _rebuildColorBlendTables();

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -46,7 +46,7 @@ const char* gMovieFileNames[MOVIE_COUNT] = {
 };
 
 // 0x518DE4
-char* gMoviePaletteFilePaths[MOVIE_COUNT] = {
+const char* gMoviePaletteFilePaths[MOVIE_COUNT] = {
     NULL,
     "art\\cuts\\introsub.pal",
     "art\\cuts\\eldersub.pal",
@@ -209,7 +209,7 @@ int gameMoviePlay(int movie, int flags)
     int oldTextColor;
     int oldFont;
     if (subtitlesEnabled) {
-        char* subtitlesPaletteFilePath;
+        const char* subtitlesPaletteFilePath;
         if (gMoviePaletteFilePaths[movie] != NULL) {
             subtitlesPaletteFilePath = gMoviePaletteFilePaths[movie];
         } else {

--- a/src/game_movie.h
+++ b/src/game_movie.h
@@ -35,7 +35,7 @@ typedef enum GameMovie {
 extern const float flt_50352A;
 
 extern const char* gMovieFileNames[MOVIE_COUNT];
-extern char* gMoviePaletteFilePaths[MOVIE_COUNT];
+extern const char* gMoviePaletteFilePaths[MOVIE_COUNT];
 extern bool gGameMovieIsPlaying;
 extern bool gGameMovieFaded;
 


### PR DESCRIPTION
Simple fix for a compiler error.
Might be included to fallout-re if you wish.