### PR TITLE
Fix dialog caps not rendered after exiting barter

### DIFF
--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2594,6 +2594,8 @@ void gameDialogTicker()
 
         if (_gd_optionsWin != -1) {
             windowUnhide(_gd_optionsWin);
+            // SFALL: Fix for the player's money not being displayed in the
+            // dialog window after leaving the barter/combat control interface.
             gameDialogRenderCaps();
         }
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2594,6 +2594,7 @@ void gameDialogTicker()
 
         if (_gd_optionsWin != -1) {
             windowUnhide(_gd_optionsWin);
+            gameDialogRenderCaps();
         }
 
         break;


### PR DESCRIPTION
Originally script-side hack for 1@2
https://github.com/rotators/Fo1in2/commit/eb5fe88887cc9a2ac00166dff2c3dc94fedbf5e2

Later adopted by SFall with different approach
https://github.com/sfall-team/sfall/blob/6b97ad4bcf6a2c57488a78d30e15a2e87074e50c/sfall/Modules/BugFixes.cpp#L2884-L2927