### PR TITLE
Fix save game preview

### DIFF
--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -626,9 +626,10 @@ int _QuickSnapShot()
     }
 
     // For preview take 640x380 area in the center of isometric window.
-    unsigned char* isoWindowBuffer = windowGetBuffer(gIsoWindow)
-        + (screenGetWidth() - ORIGINAL_ISO_WINDOW_WIDTH) / 2 * (screenGetHeight() - ORIGINAL_ISO_WINDOW_HEIGHT) / 2
-        + (screenGetWidth() - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
+    Window* window = windowGetWindow(gIsoWindow);
+    unsigned char* isoWindowBuffer = window->buffer
+        + window->width * (window->height - ORIGINAL_ISO_WINDOW_HEIGHT) / 2
+        + (window->width - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
     blitBufferToBufferStretch(isoWindowBuffer,
         ORIGINAL_ISO_WINDOW_WIDTH,
         ORIGINAL_ISO_WINDOW_HEIGHT,
@@ -1107,9 +1108,10 @@ int lsgWindowInit(int windowType)
         }
 
         // For preview take 640x380 area in the center of isometric window.
-        unsigned char* isoWindowBuffer = windowGetBuffer(gIsoWindow)
-            + (screenGetWidth() - ORIGINAL_ISO_WINDOW_WIDTH) / 2 * (screenGetHeight() - ORIGINAL_ISO_WINDOW_HEIGHT) / 2
-            + (screenGetWidth() - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
+        Window* window = windowGetWindow(gIsoWindow);
+        unsigned char* isoWindowBuffer = window->buffer
+            + window->width * (window->height - ORIGINAL_ISO_WINDOW_HEIGHT) / 2
+            + (window->width - ORIGINAL_ISO_WINDOW_WIDTH) / 2;
         blitBufferToBufferStretch(isoWindowBuffer,
             ORIGINAL_ISO_WINDOW_WIDTH,
             ORIGINAL_ISO_WINDOW_HEIGHT,


### PR DESCRIPTION
Original code didn't work okay for me when running the game at 1024x768 resolution, the preview was always skewed to the right, I guess because of an error in the formula.
I also modified the formula to use window->width and window->height instead of screenGetWidth and screenGetHeight, because the former return 1024x668 (only isoWindow) while the latter return 1024x768 (whole screen).