### PR TITLE
Properly destroy SDL window

### DIFF
--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -265,6 +265,8 @@ void windowManagerExit(void)
             textFontsExit();
             _colorsClose();
 
+            SDL_DestroyWindow(gSdlWindow);
+
             gWindowSystemInitialized = false;
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes restoring desktop resolution on linux after game exit. See #17