### PR TITLE
Tweak configGetInt() to read hex strings properly

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -5,6 +5,7 @@
 #include "platform_compat.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -178,8 +179,8 @@ bool configSetString(Config* config, const char* sectionKey, const char* key, co
     return true;
 }
 
-// 0x42C05C
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr)
+// 0x42C05C customized: atoi() replaced with strtol()
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, unsigned char base /* = 0 */ )
 {
     if (valuePtr == NULL) {
         return false;
@@ -190,7 +191,13 @@ bool configGetInt(Config* config, const char* sectionKey, const char* key, int* 
         return false;
     }
 
-    *valuePtr = atoi(stringValue);
+    char* end;
+    errno = 0;
+    long l = strtol(stringValue, &end, base); // see https://stackoverflow.com/a/6154614
+    if (((errno == ERANGE && 1 == LONG_MAX) || l > INT_MAX) || ((errno == ERANGE && l == LONG_MIN) || l < INT_MIN) || (*stringValue == '\0' || *end != '\0'))
+        return false;
+
+    *valuePtr = l;
 
     return true;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -27,7 +27,7 @@ void configFree(Config* config);
 bool configParseCommandLineArguments(Config* config, int argc, char** argv);
 bool configGetString(Config* config, const char* sectionKey, const char* key, char** valuePtr);
 bool configSetString(Config* config, const char* sectionKey, const char* key, const char* value);
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr);
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, unsigned char base = 0);
 bool configGetIntList(Config* config, const char* section, const char* key, int* arr, int count);
 bool configSetInt(Config* config, const char* sectionKey, const char* key, int value);
 bool configRead(Config* config, const char* filePath, bool isDb);


### PR DESCRIPTION
Replaces `atoi()` with `strtol()` for easy hex string -> int conversion, and gets rid of [few more headaches](https://stackoverflow.com/a/6154614/11998612) as a bonus. As SFall uses hex strings for a few options, working conversion will be needed sooner or later.

`configGetIntList()` remains unchanged; there is [only one option](https://github.com/sfall-team/sfall/blob/6b97ad4bcf6a2c57488a78d30e15a2e87074e50c/artifacts/ddraw.ini#L836-L839) which would need that and it's completely irrelevant here.