### PR TITLE
Add SFall Misc->MainMenu*FontColour

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -644,17 +644,31 @@ int mainMenuWindowInit()
     int oldFont = fontGetCurrent();
     fontSetCurrent(100);
 
+    // SFALL: Allow to change font color/flags of copyright/version text
+    //        It's the last byte ('3C' by default) that picks the colour used. The first byte supplies additional flags for this option
+    //        0x1 - change the color for version string only
+    //        0x2 - underline text (only for the version string)
+    //        0x4 - monospace font (only for the version string)
+    int fontSettings = _colorTable[21091], fontSettingsSFall = 0;
+    configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_FONT_COLOR, &fontSettingsSFall);
+    if (fontSettingsSFall && !(fontSettingsSFall & 0x010000))
+            fontSettings = fontSettingsSFall & 0xFF;
+
     // Copyright.
     msg.num = 20;
     if (messageListGetItem(&gMiscMessageList, &msg)) {
-        windowDrawText(gMainMenuWindow, msg.text, 0, 15, 460, _colorTable[21091] | 0x6000000);
+        windowDrawText(gMainMenuWindow, msg.text, 0, 15, 460, fontSettings | 0x06000000);
     }
+
+    // SFALL: Make sure font settings are applied when using 0x1 flag
+    if (fontSettingsSFall)
+        fontSettings = fontSettingsSFall;
 
     // Version.
     char version[VERSION_MAX];
     versionGetVersion(version);
     len = fontGetStringWidth(version);
-    windowDrawText(gMainMenuWindow, version, 0, 615 - len, 460, _colorTable[21091] | 0x6000000);
+    windowDrawText(gMainMenuWindow, version, 0, 615 - len, 460, fontSettings | 0x06000000);
 
     // menuup.frm
     fid = buildFid(6, 299, 0, 0, 0);
@@ -688,11 +702,18 @@ int mainMenuWindowInit()
 
     fontSetCurrent(104);
 
+    // SFALL: Allow to change font color of buttons
+    fontSettings = _colorTable[21091];
+    fontSettingsSFall = 0;
+    configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_BIG_FONT_COLOR, &fontSettingsSFall);
+    if (fontSettingsSFall)
+        fontSettings = fontSettingsSFall & 0xFF;
+
     for (int index = 0; index < MAIN_MENU_BUTTON_COUNT; index++) {
         msg.num = 9 + index;
         if (messageListGetItem(&gMiscMessageList, &msg)) {
             len = fontGetStringWidth(msg.text);
-            fontDrawText(gMainMenuWindowBuffer + 640 * (42 * index - index + 20) + 126 - (len / 2), msg.text, 640 - (126 - (len / 2)) - 1, 640, _colorTable[21091]);
+            fontDrawText(gMainMenuWindowBuffer + 640 * (42 * index - index + 20) + 126 - (len / 2), msg.text, 640 - (126 - (len / 2)) - 1, 640, fontSettings);
         }
     }
 

--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -21,6 +21,8 @@ bool sfallConfigInit(int argc, char** argv)
     }
 
     // Initialize defaults.
+    configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_BIG_FONT_COLOR, 0);
+    configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_FONT_COLOR, 0);
     configSetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_SKIP_OPENING_MOVIES_KEY, 0);
     configSetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STARTING_MAP_KEY, "");
 

--- a/src/sfall_config.h
+++ b/src/sfall_config.h
@@ -7,6 +7,8 @@
 
 #define SFALL_CONFIG_MISC_KEY "Misc"
 
+#define SFALL_CONFIG_MAIN_MENU_BIG_FONT_COLOR "MainMenuBigFontColour"
+#define SFALL_CONFIG_MAIN_MENU_FONT_COLOR "MainMenuFontColour"
 #define SFALL_CONFIG_SKIP_OPENING_MOVIES_KEY "SkipOpeningMovies"
 #define SFALL_CONFIG_STARTING_MAP_KEY "StartingMap"
 


### PR DESCRIPTION
https://github.com/sfall-team/sfall/blob/6b97ad4bcf6a2c57488a78d30e15a2e87074e50c/sfall/Modules/MainMenu.cpp#L59-L73
https://github.com/sfall-team/sfall/blob/6b97ad4bcf6a2c57488a78d30e15a2e87074e50c/sfall/Modules/MainMenu.cpp#L99-L107
https://github.com/sfall-team/sfall/blob/6b97ad4bcf6a2c57488a78d30e15a2e87074e50c/artifacts/ddraw.ini#L539-L543
Extra info about setting behavior, currently not present in ddraw.ini, provided by @NovaRain

---

NOTE: Requires #35 to work (or other way to parse hex string from .ini)