### PR TITLE
Fix inventory context menu and mouse position

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3044,13 +3044,10 @@ void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
 
     const InventoryWindowDescription* windowDescription = &(gInventoryWindowDescriptions[inventoryWindowType]);
 
-    // Maintain original position in original resolution, otherwise center it.
-    int inventoryWindowX = screenGetWidth() != 640
-        ? (screenGetWidth() - windowDescription->width) / 2
-        : windowDescription->x;
-    int inventoryWindowY = screenGetHeight() != 480
-        ? (screenGetHeight() - windowDescription->height) / 2
-        : windowDescription->y;
+    Rect windowRect;
+    windowGetRect(gInventoryWindow, &windowRect);
+    int inventoryWindowX = windowRect.left;
+    int inventoryWindowY = windowRect.top;
 
     gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
         windowDescription->width + inventoryWindowX,

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2995,7 +2995,7 @@ void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
 
     int x;
     int y;
-    mouseGetPositionInWindow(gInventoryWindow, &x, &y);
+    mouseGetPosition(&x, &y);
 
     int actionMenuItemsLength;
     const int* actionMenuItems;
@@ -3043,9 +3043,18 @@ void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
     }
 
     const InventoryWindowDescription* windowDescription = &(gInventoryWindowDescriptions[inventoryWindowType]);
+
+    // Maintain original position in original resolution, otherwise center it.
+    int inventoryWindowX = screenGetWidth() != 640
+        ? (screenGetWidth() - windowDescription->width) / 2
+        : windowDescription->x;
+    int inventoryWindowY = screenGetHeight() != 480
+        ? (screenGetHeight() - windowDescription->height) / 2
+        : windowDescription->y;
+
     gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
-        windowDescription->width + windowDescription->x,
-        windowDescription->height + windowDescription->y);
+        windowDescription->width + inventoryWindowX,
+        windowDescription->height + inventoryWindowY);
 
     InventoryCursorData* cursorData = &(gInventoryCursorData[INVENTORY_WINDOW_CURSOR_MENU]);
 
@@ -3054,8 +3063,8 @@ void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
     artGetRotationOffsets(cursorData->frm, 0, &offsetX, &offsetY);
 
     Rect rect;
-    rect.left = x - windowDescription->x - cursorData->width / 2 + offsetX;
-    rect.top = y - windowDescription->y - cursorData->height + 1 + offsetY;
+    rect.left = x - inventoryWindowX - cursorData->width / 2 + offsetX;
+    rect.top = y - inventoryWindowY - cursorData->height + 1 + offsetY;
     rect.right = rect.left + cursorData->width - 1;
     rect.bottom = rect.top + cursorData->height - 1;
 
@@ -3090,7 +3099,7 @@ void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
 
         int x;
         int y;
-        mouseGetPositionInWindow(gInventoryWindow, &x, &y);
+        mouseGetPosition(&x, &y);
         if (y - previousMouseY > 10 || previousMouseY - y > 10) {
             if (y >= previousMouseY || menuItemIndex <= 0) {
                 if (previousMouseY < y && menuItemIndex < actionMenuItemsLength - 1) {


### PR DESCRIPTION
This fixes inventory context menu position on all resolutions and mouse teleportation on higher resolutions. 

However, when using custom resolution then there is still a context menu bug in the trade window but only on the barter table area: 

![f2ce_inventory_bug](https://user-images.githubusercontent.com/1261493/173203307-821517e0-ce18-40ec-b951-516047a0757e.gif)


