### PR TITLE
Change the way the touchscreen operates

### DIFF
--- a/src/automap.cc
+++ b/src/automap.cc
@@ -322,6 +322,12 @@ void automapShow(bool isInGame, bool isUsingScanner)
     int automapWindowX = (screenGetWidth() - AUTOMAP_WINDOW_WIDTH) / 2;
     int automapWindowY = (screenGetHeight() - AUTOMAP_WINDOW_HEIGHT) / 2;
     int window = windowCreate(automapWindowX, automapWindowY, AUTOMAP_WINDOW_WIDTH, AUTOMAP_WINDOW_HEIGHT, color, WINDOW_FLAG_0x10 | WINDOW_FLAG_0x04);
+           
+    Rect offset;
+    offset.top = -3;
+    offset.bottom = 2;
+    offset.left = -15;
+    offset.right = 80;
 
     int scannerBtn = buttonCreate(window,
         111,
@@ -335,7 +341,8 @@ void automapShow(bool isInGame, bool isUsingScanner)
         frmImages[AUTOMAP_FRM_BUTTON_UP].getData(),
         frmImages[AUTOMAP_FRM_BUTTON_DOWN].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (scannerBtn != -1) {
         buttonSetCallbacks(scannerBtn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -352,7 +359,8 @@ void automapShow(bool isInGame, bool isUsingScanner)
         frmImages[AUTOMAP_FRM_BUTTON_UP].getData(),
         frmImages[AUTOMAP_FRM_BUTTON_DOWN].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (cancelBtn != -1) {
         buttonSetCallbacks(cancelBtn, _gsound_red_butt_press, _gsound_red_butt_release);
     }

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1762,6 +1762,12 @@ static int characterEditorWindowInit()
 
     characterEditorRegisterInfoAreas();
     soundContinueAll();
+        
+    Rect offset;
+    offset.top = -7;
+    offset.bottom = 7;
+    offset.left = -8;
+    offset.right = 70;
 
     btn = buttonCreate(
         gCharacterEditorWindow,
@@ -1776,7 +1782,8 @@ static int characterEditorWindowInit()
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getData(),
         _editorFrmImages[EDITOR_GRAPHIC_LILTTLE_RED_BUTTON_DOWN].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (btn != -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -1794,7 +1801,8 @@ static int characterEditorWindowInit()
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getData(),
         _editorFrmImages[EDITOR_GRAPHIC_LILTTLE_RED_BUTTON_DOWN].getData(),
         0,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (btn != -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -1812,7 +1820,8 @@ static int characterEditorWindowInit()
         _editorFrmImages[23].getData(),
         _editorFrmImages[24].getData(),
         0,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (btn != -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -341,6 +341,12 @@ static bool characterSelectorWindowInit()
     if (!_nextButtonPressedFrmImage.lock(fid)) {
         return characterSelectorWindowFatalError(false);
     }
+     
+    Rect offset;
+    offset.top = -5;
+    offset.bottom = 5;
+    offset.left = -15;
+    offset.right = 15;
 
     gCharacterSelectorWindowNextButton = buttonCreate(gCharacterSelectorWindow,
         CS_WINDOW_NEXT_BUTTON_X,
@@ -384,7 +390,8 @@ static bool characterSelectorWindowInit()
         _takeButtonNormalFrmImage.getData(),
         _takeButtonPressedFrmImage.getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (gCharacterSelectorWindowTakeButton == -1) {
         return characterSelectorWindowFatalError(false);
     }
@@ -413,7 +420,8 @@ static bool characterSelectorWindowInit()
         _modifyButtonNormalFrmImage.getData(),
         _modifyButtonPressedFrmImage.getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (gCharacterSelectorWindowModifyButton == -1) {
         return characterSelectorWindowFatalError(false);
     }
@@ -443,7 +451,8 @@ static bool characterSelectorWindowInit()
         _createButtonNormalFrmImage.getData(),
         _createButtonPressedFrmImage.getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (gCharacterSelectorWindowCreateButton == -1) {
         return characterSelectorWindowFatalError(false);
     }
@@ -473,7 +482,8 @@ static bool characterSelectorWindowInit()
         _backButtonNormalFrmImage.getData(),
         _backButtonPressedFrmImage.getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (gCharacterSelectorWindowBackButton == -1) {
         return characterSelectorWindowFatalError(false);
     }

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -286,6 +286,11 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 _colorTable[18979]);
         }
 
+        Rect offset;
+        offset.top = -5;
+        offset.bottom = 5;
+        offset.left = -18;
+        offset.right = 82;
         int btn = buttonCreate(win,
             v27 + 13,
             _doneY[dialogType] + 4,
@@ -298,7 +303,8 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
             buttonNormalFrmImage.getData(),
             buttonPressedFrmImage.getData(),
             NULL,
-            BUTTON_FLAG_TRANSPARENT);
+            BUTTON_FLAG_TRANSPARENT,
+            offset);
         if (btn != -1) {
             buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
         }
@@ -327,6 +333,11 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 backgroundFrmImage.getWidth(),
                 _colorTable[18979]);
 
+            Rect offset;
+            offset.top = -5;
+            offset.bottom = 5;
+            offset.left = -17;
+            offset.right = 82;
             int btn = buttonCreate(win,
                 doneBoxFrmImage.getWidth() + _doneX[dialogType] + 37,
                 _doneY[dialogType] + 4,
@@ -339,7 +350,8 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 buttonNormalFrmImage.getData(),
                 buttonPressedFrmImage.getData(),
                 0,
-                BUTTON_FLAG_TRANSPARENT);
+                BUTTON_FLAG_TRANSPARENT,
+                offset);
             if (btn != -1) {
                 buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
             }

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -152,6 +152,8 @@ static bool clicked = false;
 
 bool mouseDeviceGetData(MouseData* mouseState)
 {
+    mouseState->em_mode = false;
+
     if (gLastInputType == INPUT_TYPE_TOUCH) {
         mouseState->x = gTouchMouseDeltaX;
         mouseState->y = gTouchMouseDeltaY;
@@ -162,7 +164,7 @@ bool mouseDeviceGetData(MouseData* mouseState)
         gTouchMouseDeltaX = 0;
         gTouchMouseDeltaY = 0;
 
-        if (lastType == SDL_FINGERDOWN && SDL_GetTicks() - gTouchGestureLastTouchUpTimestamp > 250) {
+        if (lastType == SDL_FINGERDOWN && SDL_GetTicks() - gTouchGestureLastTouchUpTimestamp > 250 && gTouchMouseLastX > screenGetWidth() / 4) {
             longPressed = true;
         }
 
@@ -172,8 +174,9 @@ bool mouseDeviceGetData(MouseData* mouseState)
         } else if (clicked) {
             clicked = false;
             if (em_mode) {
-                mouseState->x = gTouchMouseDeltaX;
-                mouseState->y = gTouchMouseDeltaY;
+                mouseState->em_mode = em_mode;
+                mouseState->rawx = gTouchMouseLastX;
+                mouseState->rawy = gTouchMouseLastY;
             }
 
             if (gTouchMouseLastX < screenGetWidth() / 4) {

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -150,9 +150,13 @@ static Uint32 lastType = -1;
 static bool longPressed = false;
 static bool clicked = false;
 
+bool gTouch = false;
+int gTouchX;
+int gTouchY;
+
 bool mouseDeviceGetData(MouseData* mouseState)
 {
-    mouseState->em_mode = false;
+    gTouch = false;
 
     if (gLastInputType == INPUT_TYPE_TOUCH) {
         mouseState->x = gTouchMouseDeltaX;
@@ -174,9 +178,9 @@ bool mouseDeviceGetData(MouseData* mouseState)
         } else if (clicked) {
             clicked = false;
             if (em_mode) {
-                mouseState->em_mode = em_mode;
-                mouseState->rawx = gTouchMouseLastX;
-                mouseState->rawy = gTouchMouseLastY;
+                gTouch = true;
+                gTouchX = gTouchMouseLastX;
+                gTouchY = gTouchMouseLastY;
             }
 
             if (gTouchMouseLastX < screenGetWidth() / 4) {
@@ -208,8 +212,8 @@ void handleTouchEvent(SDL_Event* event)
     Uint32 type = event->tfinger.type;
     SDL_FingerID id = event->tfinger.fingerId;
 
-    if (id >= 2)
-        return;
+    //if (id >= 2) ios platform may cause some problems
+    //    return;
 
     if (type == SDL_FINGERDOWN) {
         if (lastTouchId != -1 && id != lastTouchId) {

--- a/src/dinput.h
+++ b/src/dinput.h
@@ -11,6 +11,9 @@ typedef struct MouseData {
     unsigned char buttons[2];
     int wheelX;
     int wheelY;
+    int rawx;
+    int rawy;
+    bool em_mode;
 } MouseData;
 
 typedef struct KeyboardData {

--- a/src/dinput.h
+++ b/src/dinput.h
@@ -11,9 +11,6 @@ typedef struct MouseData {
     unsigned char buttons[2];
     int wheelX;
     int wheelY;
-    int rawx;
-    int rawy;
-    bool em_mode;
 } MouseData;
 
 typedef struct KeyboardData {
@@ -37,6 +34,10 @@ void keyboardDeviceFree();
 
 void handleMouseEvent(SDL_Event* event);
 void handleTouchEvent(SDL_Event* event);
+
+extern bool gTouch;
+extern int gTouchX;
+extern int gTouchY;
 
 } // namespace fallout
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -3183,13 +3183,19 @@ int _gdialog_barter_create_win()
 
     backgroundFrmImage.unlock();
 
+                
+    Rect offset;
+    offset.top = -7;
+    offset.bottom = 7;
+    offset.left = -18;
+    offset.right = 18;
     // TRADE
-    _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 41, 163, 14, 14, -1, -1, -1, KEY_LOWERCASE_M, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), 0, BUTTON_FLAG_TRANSPARENT);
+    _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 41, 163, 14, 14, -1, -1, -1, KEY_LOWERCASE_M, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), 0, BUTTON_FLAG_TRANSPARENT, offset);
     if (_gdialog_buttons[0] != -1) {
         buttonSetCallbacks(_gdialog_buttons[0], _gsound_med_butt_press, _gsound_med_butt_release);
 
         // TALK
-        _gdialog_buttons[1] = buttonCreate(gGameDialogWindow, 584, 162, 14, 14, -1, -1, -1, KEY_LOWERCASE_T, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), 0, BUTTON_FLAG_TRANSPARENT);
+        _gdialog_buttons[1] = buttonCreate(gGameDialogWindow, 584, 162, 14, 14, -1, -1, -1, KEY_LOWERCASE_T, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), 0, BUTTON_FLAG_TRANSPARENT, offset);
         if (_gdialog_buttons[1] != -1) {
             buttonSetCallbacks(_gdialog_buttons[1], _gsound_med_butt_press, _gsound_med_butt_release);
 
@@ -4306,8 +4312,14 @@ int _gdialog_window_create()
                 _gdialog_scroll_subwin(gGameDialogWindow, 1, backgroundFrmData, v10, 0, _dialogue_subwin_len, 0);
             }
 
+                        
+            Rect offset;
+            offset.top = -7;
+            offset.bottom = 7;
+            offset.left = -18;
+            offset.right = 18;
             // BARTER/TRADE
-            _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 593, 41, 14, 14, -1, -1, -1, -1, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), NULL, BUTTON_FLAG_TRANSPARENT);
+            _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 593, 41, 14, 14, -1, -1, -1, -1, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), NULL, BUTTON_FLAG_TRANSPARENT, offset);
             if (_gdialog_buttons[0] != -1) {
                 buttonSetMouseCallbacks(_gdialog_buttons[0], NULL, NULL, NULL, gameDialogBarterButtonUpMouseUp);
                 buttonSetCallbacks(_gdialog_buttons[0], _gsound_med_butt_press, _gsound_med_butt_release);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -999,6 +999,12 @@ static bool _setup_inventory(int inventoryWindowType)
     fid = buildFid(OBJ_TYPE_INTERFACE, 9, 0, 0, 0);
     _inventoryFrmImages[1].lock(fid);
 
+    Rect offset;
+    offset.top = -7;
+    offset.bottom= 7;
+    offset.left = -95;
+    offset.right = 20;
+
     if (_inventoryFrmImages[0].isLocked() && _inventoryFrmImages[1].isLocked()) {
         btn = -1;
         switch (inventoryWindowType) {
@@ -1016,7 +1022,8 @@ static bool _setup_inventory(int inventoryWindowType)
                 _inventoryFrmImages[0].getData(),
                 _inventoryFrmImages[1].getData(),
                 NULL,
-                BUTTON_FLAG_TRANSPARENT);
+                BUTTON_FLAG_TRANSPARENT,
+                offset);
             break;
         case INVENTORY_WINDOW_TYPE_USE_ITEM_ON:
             // Cancel button
@@ -1032,7 +1039,8 @@ static bool _setup_inventory(int inventoryWindowType)
                 _inventoryFrmImages[0].getData(),
                 _inventoryFrmImages[1].getData(),
                 NULL,
-                BUTTON_FLAG_TRANSPARENT);
+                BUTTON_FLAG_TRANSPARENT,
+                offset);
             break;
         case INVENTORY_WINDOW_TYPE_LOOT:
             // Done button
@@ -1048,7 +1056,8 @@ static bool _setup_inventory(int inventoryWindowType)
                 _inventoryFrmImages[0].getData(),
                 _inventoryFrmImages[1].getData(),
                 NULL,
-                BUTTON_FLAG_TRANSPARENT);
+                BUTTON_FLAG_TRANSPARENT,
+                offset);
             break;
         }
 
@@ -5854,7 +5863,13 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
     fid = buildFid(OBJ_TYPE_INTERFACE, 9, 0, 0, 0);
     _moveFrmImages[5].lock(fid);
 
+    Rect offset;
+
     if (_moveFrmImages[4].isLocked() && _moveFrmImages[5].isLocked()) {
+        offset.top = -1;
+        offset.bottom = 1;
+        offset.left = -80;
+        offset.right = 10;
         // Done
         btn = buttonCreate(_mt_wid,
             98,
@@ -5868,11 +5883,16 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
             _moveFrmImages[4].getData(),
             _moveFrmImages[5].getData(),
             NULL,
-            BUTTON_FLAG_TRANSPARENT);
+            BUTTON_FLAG_TRANSPARENT,
+            offset);
         if (btn != -1) {
             buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
         }
-
+    
+        offset.top = -1;
+        offset.bottom = 1;
+        offset.left = -10;
+        offset.right = 80;
         // Cancel
         btn = buttonCreate(_mt_wid,
             148,
@@ -5886,7 +5906,8 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
             _moveFrmImages[4].getData(),
             _moveFrmImages[5].getData(),
             NULL,
-            BUTTON_FLAG_TRANSPARENT);
+            BUTTON_FLAG_TRANSPARENT,
+            offset);
         if (btn != -1) {
             buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
         }

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1404,6 +1404,12 @@ static int lsgWindowInit(int windowType)
 
     int btn;
 
+    Rect offset;
+    offset.top = -5;
+    offset.bottom = 5;
+    offset.left = -12;
+    offset.right = 72;
+
     btn = buttonCreate(gLoadSaveWindow,
         391,
         349,
@@ -1416,7 +1422,8 @@ static int lsgWindowInit(int windowType)
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_NORMAL].getData(),
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_PRESSED].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (btn != -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -1433,7 +1440,8 @@ static int lsgWindowInit(int windowType)
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_NORMAL].getData(),
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_PRESSED].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT, 
+        offset);
     if (btn != -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -2123,6 +2131,12 @@ static int _GetComment(int a1)
     int btn;
 
     // DONE
+    Rect offset;
+    offset.top = -5;
+    offset.bottom = 5;
+    offset.left = -15;
+    offset.right = 87;
+
     btn = buttonCreate(window,
         34,
         58,
@@ -2135,7 +2149,8 @@ static int _GetComment(int a1)
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_NORMAL].getData(),
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_PRESSED].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT, 
+        offset);
     if (btn == -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }
@@ -2153,7 +2168,8 @@ static int _GetComment(int a1)
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_NORMAL].getData(),
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_PRESSED].getData(),
         NULL,
-        BUTTON_FLAG_TRANSPARENT);
+        BUTTON_FLAG_TRANSPARENT,
+        offset);
     if (btn == -1) {
         buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -889,6 +889,12 @@ static int mainMenuWindowInit()
     offsetX = offsetY = 0;
     configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_OFFSET_X_KEY, &offsetX);
     configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_MAIN_MENU_OFFSET_Y_KEY, &offsetY);
+    
+    Rect offset;
+    offset.top = -2;
+    offset.bottom = 3;
+    offset.left = -1;
+    offset.right = 150;
 
     for (int index = 0; index < MAIN_MENU_BUTTON_COUNT; index++) {
         gMainMenuButtons[index] = buttonCreate(gMainMenuWindow,
@@ -903,7 +909,8 @@ static int mainMenuWindowInit()
             _mainMenuButtonNormalFrmImage.getData(),
             _mainMenuButtonPressedFrmImage.getData(),
             0,
-            BUTTON_FLAG_TRANSPARENT);
+            BUTTON_FLAG_TRANSPARENT,
+            offset);
         if (gMainMenuButtons[index] == -1) {
             // NOTE: Uninline.
             return main_menu_fatal_error();

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -575,6 +575,12 @@ static int pipboyWindowInit(int intent)
         buttonSetCallbacks(alarmButton, _gsound_med_butt_press, _gsound_med_butt_release);
     }
 
+    Rect offset;
+    offset.top = -3;
+    offset.bottom = 3;
+    offset.left = -2;
+    offset.right = 100;
+
     int y = 341;
     int eventCode = 500;
     for (int index = 0; index < 5; index += 1) {
@@ -591,7 +597,8 @@ static int pipboyWindowInit(int intent)
                 _pipboyFrmImages[PIPBOY_FRM_LITTLE_RED_BUTTON_UP].getData(),
                 _pipboyFrmImages[PIPBOY_FRM_LITTLE_RED_BUTTON_DOWN].getData(),
                 NULL,
-                BUTTON_FLAG_TRANSPARENT);
+                BUTTON_FLAG_TRANSPARENT,
+                offset);
             if (btn != -1) {
                 buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
             }

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -21,6 +21,8 @@
 #include "win32.h"
 #include "window_manager_private.h"
 
+#include "dinput.h"
+
 namespace fallout {
 
 #define MAX_WINDOW_COUNT (50)
@@ -1737,6 +1739,22 @@ int _GNW_check_buttons(Window* window, int* keyCodePtr)
     }
 
     *keyCodePtr = -1;
+
+    if (gTouch == true && gTouchX > window->rect.left && gTouchX < window->rect.right && gTouchY > window->rect.top && gTouchY < window->rect.bottom) {
+        int xx = gTouchX - window->rect.left;
+        int yy = gTouchY - window->rect.top;
+
+        Button* touchButton = window->buttonListHead;
+        while (touchButton != NULL && gTouch) {
+            if (!(touchButton->flags & BUTTON_FLAG_DISABLED)) {
+                if (xx > touchButton->rect.left && xx < touchButton->rect.right && yy > touchButton->rect.top && yy < touchButton->rect.bottom) {
+
+                    _win_button_press_and_release(touchButton->id);
+                }
+            }
+            touchButton = touchButton->next;
+        }
+    }
 
     if (_mouse_click_in(window->rect.left, window->rect.top, window->rect.right, window->rect.bottom)) {
         int mouseEvent = mouseGetEvent();

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -111,6 +111,8 @@ typedef struct Button {
     int id;
     int flags;
     Rect rect;
+    Rect clickRect;
+    bool ignoreMask;
     int mouseEnterEventCode;
     int mouseExitEventCode;
     int lefMouseDownEventCode;
@@ -180,6 +182,7 @@ int _GNW_check_menu_bars(int a1);
 void programWindowSetTitle(const char* title);
 bool showMesageBox(const char* str);
 int buttonCreate(int win, int x, int y, int width, int height, int mouseEnterEventCode, int mouseExitEventCode, int mouseDownEventCode, int mouseUpEventCode, unsigned char* up, unsigned char* dn, unsigned char* hover, int flags);
+int buttonCreate(int win, int x, int y, int width, int height, int mouseEnterEventCode, int mouseExitEventCode, int mouseDownEventCode, int mouseUpEventCode, unsigned char* up, unsigned char* dn, unsigned char* hover, int flags,Rect offset);
 int _win_register_text_button(int win, int x, int y, int mouseEnterEventCode, int mouseExitEventCode, int mouseDownEventCode, int mouseUpEventCode, const char* title, int flags);
 int _win_register_button_disable(int btn, unsigned char* up, unsigned char* down, unsigned char* hover);
 int _win_register_button_image(int btn, unsigned char* up, unsigned char* down, unsigned char* hover, int a5);


### PR DESCRIPTION
Change the way the touchscreen operates - instead of double-tap and triple-tap, use two-handed operation, which is more suitable for mobile phones or tablets.

Clicking the left side of the screen is the right mouse button. Long press and drag are the same as mouse operations.

There is a video as an example：

https://user-images.githubusercontent.com/26177176/196035080-da609d06-6730-4c50-8b67-6af1fb948b1f.mp4

