### PR TITLE
Refactor dude*State functions: use enum instead of magic numbers

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1396,7 +1396,7 @@ int actionUseSkill(Object* a1, Object* a2, int skill)
 
         return -1;
     case SKILL_SNEAK:
-        dudeToggleState(0);
+        dudeToggleState(DUDE_STATE_SNEAKING);
         return 0;
     default:
         debugPrint("\nskill_use: invalid skill used.");

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -690,7 +690,7 @@ int animationRegisterRunToObject(Object* owner, Object* destination, int actionP
     animationDescription->destination = destination;
 
     if ((FID_TYPE(owner->fid) == OBJ_TYPE_CRITTER && (owner->data.critter.combat.results & DAM_CRIP_LEG_ANY) != 0)
-        || (owner == gDude && dudeHasState(0) && !perkGetRank(gDude, PERK_SILENT_RUNNING))
+        || (owner == gDude && dudeHasState(DUDE_STATE_SNEAKING) && !perkGetRank(gDude, PERK_SILENT_RUNNING))
         || !artExists(buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, ANIM_RUNNING, 0, owner->rotation + 1))) {
         animationDescription->anim = ANIM_WALK;
     } else {
@@ -786,7 +786,7 @@ int animationRegisterRunToTile(Object* owner, int tile, int elevation, int actio
     animationDescription->elevation = elevation;
 
     if ((FID_TYPE(owner->fid) == OBJ_TYPE_CRITTER && (owner->data.critter.combat.results & DAM_CRIP_LEG_ANY) != 0)
-        || (owner == gDude && dudeHasState(0) && !perkGetRank(gDude, PERK_SILENT_RUNNING))
+        || (owner == gDude && dudeHasState(DUDE_STATE_SNEAKING) && !perkGetRank(gDude, PERK_SILENT_RUNNING))
         || !artExists(buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, ANIM_RUNNING, 0, owner->rotation + 1))) {
         animationDescription->anim = ANIM_WALK;
     } else {
@@ -3043,7 +3043,7 @@ int _dude_run(int a1)
     }
 
     if (!perkGetRank(gDude, PERK_SILENT_RUNNING)) {
-        dudeDisableState(0);
+        dudeDisableState(DUDE_STATE_SNEAKING);
     }
 
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1186,8 +1186,8 @@ int characterEditorShow(bool isCreationMode)
         characterEditorRestorePlayer();
     }
 
-    if (dudeHasState(0x03)) {
-        dudeDisableState(0x03);
+    if (dudeHasState(DUDE_STATE_LEVEL_UP_AVAILABLE)) {
+        dudeDisableState(DUDE_STATE_LEVEL_UP_AVAILABLE);
     }
 
     interfaceRenderHitPoints(false);


### PR DESCRIPTION
Done according to
```cpp
typedef enum DudeState {
    DUDE_STATE_SNEAKING = 0,
    DUDE_STATE_LEVEL_UP_AVAILABLE = 3,
    DUDE_STATE_ADDICTED = 4,
} DudeState;
```

in `critter.h`