### PR TITLE
fix armeabi-v7a crash - SIGBUS(BUS_ADRALN)

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -307,6 +307,8 @@ bool heapBlockAllocate(Heap* heap, int* handleIndexPtr, int size, int a4)
     int blockSize;
     HeapHandle* handle;
 
+    size += 4 - size % 4;
+
     if (heap == NULL || handleIndexPtr == NULL || size == 0) {
         goto err;
     }


### PR DESCRIPTION
heapBlockAllocate arg size cause SIGBUS(BUS_ADRALN) crash， made it memory align to solve this problem