### PR TITLE
support loading msg files for traditional Chinese version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,9 +337,11 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE ${FPATTERN_INCLUDE_DIR})
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     add_subdirectory("third_party/zlib")
     add_subdirectory("third_party/sdl2")
+    add_subdirectory("third_party/sdlttf")
 else()
     find_package(ZLIB)
     find_package(SDL2)
+    find_package(SDL2TTF)
 endif()
 
 target_link_libraries(${EXECUTABLE_NAME} ${ZLIB_LIBRARIES})
@@ -347,6 +349,9 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE ${ZLIB_INCLUDE_DIRS})
 
 target_link_libraries(${EXECUTABLE_NAME} ${SDL2_LIBRARIES})
 target_include_directories(${EXECUTABLE_NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
+
+target_link_libraries(${EXECUTABLE_NAME} ${SDL2TTF_LIBRARIES})
+target_include_directories(${EXECUTABLE_NAME} PRIVATE ${SDL2TTF_INCLUDE_DIRS})
 
 if(APPLE)
     if(IOS)

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -88,6 +88,7 @@ namespace fallout {
 #define GERMAN "german"
 #define ITALIAN "italian"
 #define SPANISH "spanish"
+#define TCHINESE "cht"
 
 typedef enum GameDifficulty {
     GAME_DIFFICULTY_EASY,

--- a/src/message.cc
+++ b/src/message.cc
@@ -476,6 +476,7 @@ static int _message_load_field(File* file, char* str)
     int len;
 
     len = 0;
+    bool ischt = compat_stricmp(settings.system.language.c_str(), TCHINESE) == 0;
 
     while (1) {
         ch = fileReadChar(file);
@@ -509,6 +510,13 @@ static int _message_load_field(File* file, char* str)
         if (ch != '\n') {
             *(str + len) = ch;
             len++;
+
+            if (ischt && ch >= 0x81 && ch <= 0xfe) { 
+                // language is "cht", and it's a big5 encoding char
+                ch = fileReadChar(file);
+                *(str + len) = ch;
+                len++;
+            }
 
             if (len > 1024) {
                 debugPrint("\nError reading message file - text exceeds limit.\n");

--- a/third_party/sdlttf/CMakeLists.txt
+++ b/third_party/sdlttf/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Build static lib only
+set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
+set(BUILD_SHARED_LIBS OFF)
+
+
+if (ANDROID)
+    set(SDL_STATIC_PIC ON)
+endif()
+
+include(FetchContent)
+
+FetchContent_Declare(sdl2ttf
+    GIT_REPOSITORY "https://github.com/libsdl-org/SDL_ttf"
+    GIT_TAG "release-2.20.1"
+)
+
+FetchContent_GetProperties(sdl2ttf)
+if (NOT sdl2ttf_POPULATED)
+    FetchContent_Populate(sdl2ttf)
+endif()
+
+add_subdirectory(${sdl2ttf_SOURCE_DIR} ${sdl2ttf_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+set(SDL2TTF_INCLUDE_DIRS ${sdl2_SOURCE_DIR} ${sdl2_BINARY_DIR} PARENT_SCOPE)
+set(SDL2TTF_LIBRARIES SDL2_ttf::SDL2_ttf-static PARENT_SCOPE)


### PR DESCRIPTION
The traditional Chinese version of fallout 2 use big5 encoding to store texts.
https://en.wikipedia.org/wiki/Big5

It use two bytes to store one Chinese character.
If second byte is '}'(hex 0x7d), the "_message_load_field" will return error.

After apply this patch, the game will enter the main menu. But still has the font issue.
In official traditional Chinese version of fallout 2, it use Windows system font to render texts.
My plan is add ttf font render support with sdl-ttf lib.