### PR TITLE
Add mobile keyboard support

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1931,6 +1931,8 @@ static int _get_input_str(int win, int cancelKeyCode, char* text, int maxLength,
 
     windowRefresh(win);
 
+    beginTextInput();
+
     int blinkingCounter = 3;
     bool blink = false;
 
@@ -1993,6 +1995,8 @@ static int _get_input_str(int win, int cancelKeyCode, char* text, int maxLength,
         renderPresent();
         sharedFpsLimiter.throttle();
     }
+
+    endTextInput();
 
     if (rc == 0 || nameLength > 0) {
         copy[nameLength] = '\0';

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -1089,6 +1089,8 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
 
     windowRefresh(win);
 
+    beginTextInput();
+
     int blinkingCounter = 3;
     bool blink = false;
 
@@ -1352,6 +1354,8 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
         renderPresent();
         sharedFpsLimiter.throttle();
     }
+
+    endTextInput();
 
     if (rc == 0) {
         if (fileNameCopyLength != 0) {

--- a/src/input.cc
+++ b/src/input.cc
@@ -1209,4 +1209,14 @@ static void idleImpl()
     SDL_Delay(125);
 }
 
+void beginTextInput()
+{
+    SDL_StartTextInput();
+}
+
+void endTextInput()
+{
+    SDL_StopTextInput();
+}
+
 } // namespace fallout

--- a/src/input.h
+++ b/src/input.h
@@ -44,6 +44,9 @@ void _GNW95_process_message();
 void _GNW95_clear_time_stamps();
 void _GNW95_lost_focus();
 
+void beginTextInput();
+void endTextInput();
+
 } // namespace fallout
 
 #endif /* FALLOUT_INPUT_H_ */

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -2213,6 +2213,8 @@ static int _get_input_str2(int win, int doneKeyCode, int cancelKeyCode, char* de
     windowRefresh(win);
     renderPresent();
 
+    beginTextInput();
+
     int blinkCounter = 3;
     bool blink = false;
 
@@ -2281,6 +2283,8 @@ static int _get_input_str2(int win, int doneKeyCode, int cancelKeyCode, char* de
         renderPresent();
         sharedFpsLimiter.throttle();
     }
+
+    endTextInput();
 
     if (rc == 0) {
         text[textLength] = '\0';


### PR DESCRIPTION
SDL finally harmonised Android vs iOS differences in text input, making it dead simple to implement. At this time text input is limited to ASCII characters.

Closes #127 
Closes #168
See #182
