### PR TITLE
Fix crash in _map_age_dead_critters

### DIFF
--- a/src/object.cc
+++ b/src/object.cc
@@ -2133,25 +2133,16 @@ Object* objectFindFirst()
 {
     gObjectFindElevation = 0;
 
-    ObjectListNode* objectListNode;
     for (gObjectFindTile = 0; gObjectFindTile < HEX_GRID_SIZE; gObjectFindTile++) {
-        objectListNode = gObjectListHeadByTile[gObjectFindTile];
-        if (objectListNode) {
-            break;
+        ObjectListNode* objectListNode = gObjectListHeadByTile[gObjectFindTile];
+        while (objectListNode != NULL) {
+            Object* object = objectListNode->obj;
+            if (!artIsObjectTypeHidden(FID_TYPE(object->fid))) {
+                gObjectFindLastObjectListNode = objectListNode;
+                return object;
+            }
+            objectListNode = objectListNode->next;
         }
-    }
-
-    if (gObjectFindTile == HEX_GRID_SIZE) {
-        gObjectFindLastObjectListNode = NULL;
-        return NULL;
-    }
-
-    while (objectListNode != NULL) {
-        if (artIsObjectTypeHidden(FID_TYPE(objectListNode->obj->fid)) == 0) {
-            gObjectFindLastObjectListNode = objectListNode;
-            return objectListNode->obj;
-        }
-        objectListNode = objectListNode->next;
     }
 
     gObjectFindLastObjectListNode = NULL;
@@ -2167,9 +2158,14 @@ Object* objectFindNext()
 
     ObjectListNode* objectListNode = gObjectFindLastObjectListNode->next;
 
-    while (gObjectFindTile < HEX_GRID_SIZE) {
+    while (true) {
         if (objectListNode == NULL) {
-            objectListNode = gObjectListHeadByTile[gObjectFindTile++];
+            gObjectFindTile++;
+            if (gObjectFindTile >= HEX_GRID_SIZE) {
+                break;
+            }
+
+            objectListNode = gObjectListHeadByTile[gObjectFindTile];
         }
 
         while (objectListNode != NULL) {
@@ -2219,9 +2215,14 @@ Object* objectFindNextAtElevation()
 
     ObjectListNode* objectListNode = gObjectFindLastObjectListNode->next;
 
-    while (gObjectFindTile < HEX_GRID_SIZE) {
+    while (true) {
         if (objectListNode == NULL) {
-            objectListNode = gObjectListHeadByTile[gObjectFindTile++];
+            gObjectFindTile++;
+            if (gObjectFindTile >= HEX_GRID_SIZE) {
+                break;
+            }
+
+            objectListNode = gObjectListHeadByTile[gObjectFindTile];
         }
 
         while (objectListNode != NULL) {


### PR DESCRIPTION
This PR fixes crashing in `_map_age_dead_critters` function because the same object destroyed twice.

I have a save file on Fallout Of Nevada where it happens. Probably reproduceable via keeping corpse on the lowest-index tile and waiting for a while.

It was caused by `objectFindFirst`/`objectFindNext` functions which returned the same object twice due to off-by-one error in `gObjectFindTile` variable.

After calling `objectFindFirst()` function `gObjectFindTile` variable holds index of tile where object was found. After few calls to `objectFindNext` when this tile is exhausted we do postfix increment on `gObjectFindTile` so we start to fetch objects from the same tile. When tile is exhausted second time then we jump to the next tile because `gObjectFindTile` already incremented in the first exhausting.

So, for this function we consider `gObjectFindTile` as a "tile where to lookup when current list ends". It should always be next tile.

Of course it is possible to keep `gObjectFindTile` meaning as "tile where we currently iterating" but this will lead to more changes in `objectFindNext` function, not just changing postfix increment into prefix but also checking `gObjectFindTile` is still in the range.

This PR affects `objectFindFirst`/`objectFindNext` and `objectFindFirstAtElevation`/`objectFindNextAtElevation` functions. Other function `objectFindFirstAtLocation` sets `gObjectFindTile` variable but `objectFindNextAtLocation` is not using it. 

