### PR TITLE
Ignore channels in acm files

### DIFF
--- a/src/audio.cc
+++ b/src/audio.cc
@@ -58,7 +58,7 @@ static int audioSoundDecoderReadHandler(void* data, void* buffer, unsigned int s
 
 // AudioOpen
 // 0x41A2EC
-int audioOpen(const char* fname, int* channels, int* sampleRate)
+int audioOpen(const char* fname, int* sampleRate)
 {
     char path[80];
     snprintf(path, sizeof(path), "%s", fname);
@@ -101,7 +101,6 @@ int audioOpen(const char* fname, int* channels, int* sampleRate)
         audioFile->soundDecoder = soundDecoderInit(audioSoundDecoderReadHandler, audioFile->stream, &(audioFile->channels), &(audioFile->sampleRate), &(audioFile->fileSize));
         audioFile->fileSize *= 2;
 
-        *channels = audioFile->channels;
         *sampleRate = audioFile->sampleRate;
     } else {
         audioFile->fileSize = fileGetSize(stream);

--- a/src/audio.h
+++ b/src/audio.h
@@ -5,7 +5,7 @@ namespace fallout {
 
 typedef bool(AudioQueryCompressedFunc)(char* filePath);
 
-int audioOpen(const char* fname, int* channels, int* sampleRate);
+int audioOpen(const char* fname, int* sampleRate);
 int audioClose(int handle);
 int audioRead(int handle, void* buffer, unsigned int size);
 long audioSeek(int handle, long offset, int origin);

--- a/src/audio_file.cc
+++ b/src/audio_file.cc
@@ -57,7 +57,7 @@ static int audioFileSoundDecoderReadHandler(void* data, void* buffer, unsigned i
 }
 
 // 0x41A88C
-int audioFileOpen(const char* fname, int* channels, int* sampleRate)
+int audioFileOpen(const char* fname, int* sampleRate)
 {
     char path[COMPAT_MAX_PATH];
     strcpy(path, fname);
@@ -99,7 +99,6 @@ int audioFileOpen(const char* fname, int* channels, int* sampleRate)
         audioFile->soundDecoder = soundDecoderInit(audioFileSoundDecoderReadHandler, audioFile->stream, &(audioFile->channels), &(audioFile->sampleRate), &(audioFile->fileSize));
         audioFile->fileSize *= 2;
 
-        *channels = audioFile->channels;
         *sampleRate = audioFile->sampleRate;
     } else {
         audioFile->fileSize = getFileSize(stream);

--- a/src/audio_file.h
+++ b/src/audio_file.h
@@ -5,7 +5,7 @@ namespace fallout {
 
 typedef bool(AudioFileQueryCompressedFunc)(char* filePath);
 
-int audioFileOpen(const char* fname, int* channels, int* sampleRate);
+int audioFileOpen(const char* fname, int* sampleRate);
 int audioFileClose(int handle);
 int audioFileRead(int handle, void* buf, unsigned int size);
 long audioFileSeek(int handle, long offset, int origin);

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -157,7 +157,7 @@ static int _gsound_speech_volume_get_set(int volume);
 static void speechPause();
 static void speechResume();
 static void _gsound_bkg_proc();
-static int gameSoundFileOpen(const char* fname, int* channels, int* sampleRate);
+static int gameSoundFileOpen(const char* fname, int* sampleRate);
 static long _gsound_write_();
 static long gameSoundFileTellNotImplemented(int handle);
 static int gameSoundFileWrite(int handle, const void* buf, unsigned int size);
@@ -1548,7 +1548,7 @@ void _gsound_bkg_proc()
 }
 
 // 0x451A08
-int gameSoundFileOpen(const char* fname, int* channels, int* sampleRate)
+int gameSoundFileOpen(const char* fname, int* sampleRate)
 {
     File* stream = fileOpen(fname, "rb");
     if (stream == NULL) {

--- a/src/sound.cc
+++ b/src/sound.cc
@@ -49,7 +49,7 @@ static long soundFileSize(int fileHandle);
 static long soundTellData(int fileHandle);
 static int soundWriteData(int fileHandle, const void* buf, unsigned int size);
 static int soundReadData(int fileHandle, void* buf, unsigned int size);
-static int soundOpenData(const char* filePath, int* channels, int* sampleRate);
+static int soundOpenData(const char* filePath, int* sampleRate);
 static long soundSeekData(int fileHandle, long offset, int origin);
 static int soundCloseData(int fileHandle);
 static char* soundFileManglerDefaultImpl(char* fname);
@@ -223,7 +223,7 @@ static int soundReadData(int fileHandle, void* buf, unsigned int size)
 }
 
 // 0x4AC768
-static int soundOpenData(const char* filePath, int* channels, int* sampleRate)
+static int soundOpenData(const char* filePath, int* sampleRate)
 {
     int flags;
 
@@ -616,7 +616,7 @@ int soundLoad(Sound* sound, char* filePath)
         return gSoundLastError;
     }
 
-    sound->io.fd = sound->io.open(gSoundFileNameMangler(filePath), &(sound->channels), &(sound->rate));
+    sound->io.fd = sound->io.open(gSoundFileNameMangler(filePath), &(sound->rate));
     if (sound->io.fd == -1) {
         gSoundLastError = SOUND_FILE_NOT_FOUND;
         return gSoundLastError;

--- a/src/sound.h
+++ b/src/sound.h
@@ -46,7 +46,7 @@ typedef enum SoundError {
     SOUND_ERR_COUNT,
 } SoundError;
 
-typedef int SoundOpenProc(const char* filePath, int* channels, int* sampleRate);
+typedef int SoundOpenProc(const char* filePath, int* sampleRate);
 typedef int SoundCloseProc(int fileHandle);
 typedef int SoundReadProc(int fileHandle, void* buf, unsigned int size);
 typedef int SoundWriteProc(int fileHandle, const void* buf, unsigned int size);

--- a/src/sound_effects_cache.cc
+++ b/src/sound_effects_cache.cc
@@ -154,7 +154,7 @@ void soundEffectsCacheFlush()
 
 // sfxc_cached_open
 // 0x4A915C
-int soundEffectsCacheFileOpen(const char* fname, int* channels, int* sampleRate)
+int soundEffectsCacheFileOpen(const char* fname, int* sampleRate)
 {
     if (_sfxc_files_open >= SOUND_EFFECTS_MAX_COUNT) {
         return -1;

--- a/src/sound_effects_cache.h
+++ b/src/sound_effects_cache.h
@@ -11,7 +11,7 @@ int soundEffectsCacheInit(int cache_size, const char* effectsPath);
 void soundEffectsCacheExit();
 int soundEffectsCacheInitialized();
 void soundEffectsCacheFlush();
-int soundEffectsCacheFileOpen(const char* fname, int* channels, int* sampleRate);
+int soundEffectsCacheFileOpen(const char* fname, int* sampleRate);
 int soundEffectsCacheFileClose(int handle);
 int soundEffectsCacheFileRead(int handle, void* buf, unsigned int size);
 int soundEffectsCacheFileWrite(int handle, const void* buf, unsigned int size);


### PR DESCRIPTION
Apparently number of channels specified in acm file headers is not reliable. This PR removes reporting number of channels introduced in 69e4adf5b321e64b4be9db1a313c91cabe50dfd5, keeping only sample rate to support HQ music.

Fixes #268 