### PR TITLE
Use touchscreen as touchscreen

### DIFF
--- a/src/touch.cc
+++ b/src/touch.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <stack>
 
+#include "mouse.h"
 #include "svga.h"
 
 namespace fallout {
@@ -14,7 +15,7 @@ namespace fallout {
 #define MAX_TOUCHES 10
 
 #define TAP_MAXIMUM_DURATION 75
-#define PAN_MINIMUM_MOVEMENT 4
+#define PAN_MINIMUM_MOVEMENT 15
 #define LONG_PRESS_MINIMUM_DURATION 500
 
 struct TouchLocation {
@@ -271,6 +272,8 @@ void touch_process_gesture()
                 currentGesture.y = currentCentroid.y;
                 gestureEventsQueue.push(currentGesture);
             }
+
+            _mouse_set_position(currentCentroid.x, currentCentroid.y);
         }
     }
 }

--- a/src/touch.cc
+++ b/src/touch.cc
@@ -273,7 +273,9 @@ void touch_process_gesture()
                 gestureEventsQueue.push(currentGesture);
             }
 
+            mouseHideCursor();
             _mouse_set_position(currentCentroid.x, currentCentroid.y);
+            mouseShowCursor();
         }
     }
 }


### PR DESCRIPTION
This PR changes how touchscreen is operated. Now user can tap game buttons as everyone expects - you tap where you want to click.
Other gestures works the same way as before: slide to move mouse (useful to hover), tap with two fingers for right-mouse click, slide with two fingers for scrolling.

I'v tested this for a while on my 10' tablet and I did not notice any issues with such approach. Also I never played on my mobile phone and I think no one should do so because mobile screen is to small for this game.

As usual you can test this approach online on https://fallout-nevada.ru/