### PR TITLE
Add support for SCALE_2X

### DIFF
--- a/src/svga.cc
+++ b/src/svga.cc
@@ -102,6 +102,7 @@ void _zero_vid_mem()
 int _GNW95_init_mode_ex(int width, int height, int bpp)
 {
     bool fullscreen = true;
+    int scale = 1;
 
     Config resolutionConfig;
     if (configInit(&resolutionConfig)) {
@@ -121,6 +122,18 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
                 fullscreen = !windowed;
             }
 
+            int scaleValue;
+            if (configGetInt(&resolutionConfig, "MAIN", "SCALE_2X", &scaleValue)) {
+                scale = scaleValue + 1; // 0 = 1x, 1 = 2x
+                // Only allow scaling if resulting game resolution is >= 640x480
+                if ((width / scale) < 640 || (height / scale) < 480) {
+                    scale = 1;
+                } else {
+                    width /= scale;
+                    height /= scale;
+                }
+            }
+
             configGetBool(&resolutionConfig, "IFACE", "IFACE_BAR_MODE", &gInterfaceBarMode);
             configGetInt(&resolutionConfig, "IFACE", "IFACE_BAR_WIDTH", &gInterfaceBarWidth);
             configGetInt(&resolutionConfig, "IFACE", "IFACE_BAR_SIDE_ART", &gInterfaceSidePanelsImageId);
@@ -129,7 +142,7 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
         configFree(&resolutionConfig);
     }
 
-    if (_GNW95_init_window(width, height, fullscreen) == -1) {
+    if (_GNW95_init_window(width, height, fullscreen, scale) == -1) {
         return -1;
     }
 
@@ -157,7 +170,7 @@ int _init_vesa_mode(int width, int height)
 }
 
 // 0x4CAEDC
-int _GNW95_init_window(int width, int height, bool fullscreen)
+int _GNW95_init_window(int width, int height, bool fullscreen, int scale)
 {
     if (gSdlWindow == NULL) {
         SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
@@ -172,7 +185,7 @@ int _GNW95_init_window(int width, int height, bool fullscreen)
             windowFlags |= SDL_WINDOW_FULLSCREEN;
         }
 
-        gSdlWindow = SDL_CreateWindow(gProgramWindowTitle, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, windowFlags);
+        gSdlWindow = SDL_CreateWindow(gProgramWindowTitle, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width * scale, height * scale, windowFlags);
         if (gSdlWindow == NULL) {
             return -1;
         }

--- a/src/svga.h
+++ b/src/svga.h
@@ -31,7 +31,7 @@ void _get_start_mode_();
 void _zero_vid_mem();
 int _GNW95_init_mode_ex(int width, int height, int bpp);
 int _init_vesa_mode(int width, int height);
-int _GNW95_init_window(int width, int height, bool fullscreen);
+int _GNW95_init_window(int width, int height, bool fullscreen, int scale);
 int directDrawInit(int width, int height, int bpp);
 void directDrawFree();
 void directDrawSetPaletteInRange(unsigned char* a1, int a2, int a3);


### PR DESCRIPTION
This PR adds support for the Fallout high-resolution pack's `SCALE_2X` option in `f2_res.ini`, which pixel-doubles the game window's contents for crisp graphics on higher-resolution monitors. This is basically identical to the PR I made for fallout1-ce [here](https://github.com/alexbatalov/fallout1-ce/pull/75). Brings #3 closer to completion.

![Screen Shot 2023-06-12 at 6 05 24 PM](https://github.com/alexbatalov/fallout2-ce/assets/18648066/b7a461cb-48f1-4fec-8421-4708d350e381)
![Screen Shot 2023-06-12 at 6 06 10 PM](https://github.com/alexbatalov/fallout2-ce/assets/18648066/ed9f8c77-669a-49f4-9982-27c516f12792)

This also allows for 3x or 4x scaling on HiDPI monitors by setting `SCALE_2X` to 2 or 3, respectively!