### PR TITLE
Clear input envents on combat turn

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3223,6 +3223,7 @@ static int _combat_turn(Object* a1, bool a2)
     } else {
         if (a1 == gDude) {
             keyboardReset();
+            inputEventQueueReset();
             interfaceRenderArmorClass(true);
             _combat_free_move = 2 * perkGetRank(gDude, PERK_BONUS_MOVE);
             interfaceRenderActionPoints(gDude->data.critter.combat.ap, _combat_free_move);

--- a/src/input.cc
+++ b/src/input.cc
@@ -292,6 +292,8 @@ void inputEventQueueReset()
 {
     gInputEventQueueReadIndex = -1;
     gInputEventQueueWriteIndex = 0;
+    SDL_Event e;
+    while (SDL_PollEvent(&e)) {} // Clear all input events
 }
 
 // 0x4C8D1C


### PR DESCRIPTION
Issue: if a user skips turn by clicking end a combat turn button the cursor becomes frozen in "watch" mode but all input events are queued. If a user clicked while the AI turn is not ended then the next user's turn is skipped.

Fix: clear input queue each time before user's turn.