### PR TITLE
Upgrade zlib to 1.3

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(zlib
     GIT_REPOSITORY "https://github.com/madler/zlib"
-    GIT_TAG "v1.2.11"
+    GIT_TAG "v1.3"
 )
 
 FetchContent_GetProperties(zlib)


### PR DESCRIPTION
When cmake prepares build files, it issues a warning like below. This renders build impossible. Upgrading zlib to 1.3 is sufficient to fix the problem.

```
CMake Deprecation Warning at build/_deps/zlib-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions
```

build system: macOS Monterey M2, cmake and other packages are installed via MacPorts.
My current version of cmake: `3.24.4`. 