### PR TITLE
Fix wrong pointer dereferencing in aiFindAttackers

### DIFF
--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -1464,7 +1464,7 @@ static int aiFindAttackers(Object* critter, Object** whoHitMePtr, Object** whoHi
         *whoHitFriendPtr = NULL;
     }
 
-    if (*whoHitByFriendPtr != NULL) {
+    if (whoHitByFriendPtr != NULL) {
         *whoHitByFriendPtr = NULL;
     }
 


### PR DESCRIPTION
Few lines above we check that arguments are not null pointer but for the last argument we check actual pointer value. 

This is very interesting issue because it caused crash on webassembly build (I will make a PR with webassembly at some point when it will be ready)