### PR TITLE
Improve mouse on mobile devices

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -2629,7 +2629,7 @@ static void _combat_begin(Object* a1)
             reg_anim_end();
 
             while (animationIsBusy(v1)) {
-                _process_bk();
+                inputGetInput();
             }
         }
     }
@@ -2796,7 +2796,7 @@ static void _combat_over()
             reg_anim_end();
 
             while (animationIsBusy(critter)) {
-                _process_bk();
+                inputGetInput();
             }
         }
     }
@@ -3113,7 +3113,7 @@ void _combat_turn_run()
     while (_combat_turn_running > 0) {
         sharedFpsLimiter.mark();
 
-        _process_bk();
+        inputGetInput();
 
         renderPresent();
         sharedFpsLimiter.throttle();

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1280,7 +1280,7 @@ int gameMouseSetCursor(int cursor)
         }
 
         unsigned int delay = 1000 / artGetFramesPerSecond(mouseCursorFrm);
-        if (getTicksBetween(tick, gGameMouseAnimatedCursorLastUpdateTimestamp) < delay) {
+        if (getTicksBetween(tick, gGameMouseAnimatedCursorLastUpdateTimestamp) < delay && cursor == gGameMouseCursor) {
             shouldUpdate = false;
         } else {
             if (artGetFrameCount(mouseCursorFrm) <= gGameMouseAnimatedCursorNextFrame) {


### PR DESCRIPTION
When playing the game using a touchscreen, the mouse is frozen during the enemy's turn and the start and end animations.
This commit will fix this problem.