### PR TITLE
fix CMake condition to allow build on OpenBSD & FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ add_subdirectory("third_party/fpattern")
 target_link_libraries(${EXECUTABLE_NAME} ${FPATTERN_LIBRARY})
 target_include_directories(${EXECUTABLE_NAME} PRIVATE ${FPATTERN_INCLUDE_DIR})
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD"))
     add_subdirectory("third_party/zlib")
     add_subdirectory("third_party/sdl2")
 else()


### PR DESCRIPTION
Following [fallout1-ce \#74](<https://github.com/alexbatalov/fallout1-ce/pull/74>), the same logic can be applied to OpenBSD.

this should also fix FreeBSD builds, but i don't have a FreeBSD machine to test with atm.

this allows the build to proceed if the internal SDL2 isn't used, and instead uses the SDL2 from the ports tree.