### PR TITLE
fix obj_can_see_obj not working in release build

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1799,7 +1799,7 @@ static void opObjectCanSeeObject(Program* program)
         if (object2->elevation == object1->elevation) {
             if (object2->tile != -1 && object1->tile != -1) {
                 if (isWithinPerception(object1, object2)) {
-                    Object* obstacle;
+                    Object* obstacle = nullptr;
                     _make_straight_path(object1, object1->tile, object2->tile, nullptr, &obstacle, 16);
                     if (obstacle == object2) {
                         canSee = true;


### PR DESCRIPTION
uninitialized values ​​are random numbers in release build, this makes obj "can't see" in release build