### PR TITLE
change min resolution to 799 so movies don't crash

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2483,7 +2483,7 @@ static void customInterfaceBarInit()
 {
     gInterfaceBarContentOffset = gInterfaceBarWidth - 640;
 
-    if (gInterfaceBarContentOffset > 0 && screenGetWidth() > 640) {
+    if (gInterfaceBarContentOffset > 0 && screenGetWidth() > 799) {
         char path[COMPAT_MAX_PATH];
         snprintf(path, sizeof(path), "art\\intrface\\HR_IFACE_%d.FRM", gInterfaceBarWidth);
 


### PR DESCRIPTION
Between v1.2 and v1.3  the 640 test was added. In my testing this crashes at 768,  784 and 799. Movies load fine a 800 and since it is testing the width I suppose don't upward of 640.

May need more testing, but don't know what beyond works locally.  Do you have a methodology for that?