### PR TITLE
Fix debug print on non-Windows platforms and Quick-save message

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -138,7 +138,7 @@ int debugPrint(const char* format, ...)
 
         rc = gDebugPrintProc(string);
     } else {
-#ifdef _DEBUG
+#ifndef NDEBUG
         SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO, format, args);
 #endif
         rc = -1;

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -390,6 +390,16 @@ int lsgSaveGame(int mode)
             fileClose(_flptr);
         }
 
+        if (!messageListInit(&gLoadSaveMessageList)) {
+            return -1;
+        }
+
+        char path[COMPAT_MAX_PATH];
+        snprintf(path, sizeof(path), "%s%s", asc_5186C8, "LSGAME.MSG");
+        if (!messageListLoad(&gLoadSaveMessageList, path)) {
+            return -1;
+        }
+
         _snapshotBuf = nullptr;
         int v6 = _QuickSnapShot();
         if (v6 == 1) {
@@ -407,16 +417,6 @@ int lsgSaveGame(int mode)
 
         if (v6 != -1) {
             return 1;
-        }
-
-        if (!messageListInit(&gLoadSaveMessageList)) {
-            return -1;
-        }
-
-        char path[COMPAT_MAX_PATH];
-        snprintf(path, sizeof(path), "%s%s", asc_5186C8, "LSGAME.MSG");
-        if (!messageListLoad(&gLoadSaveMessageList, path)) {
-            return -1;
         }
 
         soundPlayFile("iisxxxx1");


### PR DESCRIPTION
_DEBUG is a non-standard define used by Visual Studio while NDEBUG is defined by CMake.

Fix "Game Saved" message error when quick saving due to uninitialized LSGAME.MSG.