### PR TITLE
Mouse sensitivity fix + aligning ranges

### DIFF
--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -700,7 +700,7 @@ void _mouse_get_raw_state(int* out_x, int* out_y, int* out_buttons)
 // 0x4CAC3C
 void mouseSetSensitivity(double value)
 {
-    if (value > 0 && value < 2.0) {
+    if (value >= 1.0 && value <= 2.5) {
         gMouseSensitivity = value;
     }
 }


### PR DESCRIPTION
I noticed that the application of the mouse sensitivity when set to maximum seems to be a bit broken while working on my Switch port. It would initialise with 1.0 even though it would be set to 2.5 in fallout2.cfg and not change if I set it to max. I built on Windows to be sure, and it seems it's properly applied now. 

I also just fixed the range as it only goes from 1.0 to 2.5.

Thanks!
