### PR TITLE
Video stretching

### DIFF
--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -23,9 +23,6 @@
 
 namespace fallout {
 
-#define GAME_MOVIE_WINDOW_WIDTH 640
-#define GAME_MOVIE_WINDOW_HEIGHT 480
-
 static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath);
 
 // 0x50352A
@@ -170,18 +167,29 @@ int gameMoviePlay(int movie, int flags)
         gGameMovieFaded = true;
     }
 
-    int gameMovieWindowX = (screenGetWidth() - GAME_MOVIE_WINDOW_WIDTH) / 2;
-    int gameMovieWindowY = (screenGetHeight() - GAME_MOVIE_WINDOW_HEIGHT) / 2;
-    int win = windowCreate(gameMovieWindowX,
-        gameMovieWindowY,
-        GAME_MOVIE_WINDOW_WIDTH,
-        GAME_MOVIE_WINDOW_HEIGHT,
+    // Create a full-screen movie window using current screen resolution
+    // Changed this to fix subtitles with stretched movies in movie.cc
+    int screenWidth = screenGetWidth();
+    int screenHeight = screenGetHeight();
+
+    int movieWindowX = 0;
+    int movieWindowY = 0;
+    int movieWindowWidth = screenWidth;
+    int movieWindowHeight = screenHeight;
+
+    int win = windowCreate(
+        movieWindowX,
+        movieWindowY,
+        movieWindowWidth,
+        movieWindowHeight,
         0,
         WINDOW_MODAL);
+
     if (win == -1) {
         gGameMovieIsPlaying = false;
         return -1;
     }
+
 
     if ((flags & GAME_MOVIE_STOP_MUSIC) != 0) {
         backgroundSoundDelete();

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -23,34 +23,22 @@
 
 namespace fallout {
 
-static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath);
+static char *gameMovieBuildSubtitlesFilePath(char *movieFilePath);
 
 // 0x50352A
 static const float flt_50352A = 0.032258064f;
 
 // 0x518DA0
-static const char* gMovieFileNames[MOVIE_COUNT] = {
-    "iplogo.mve",
-    "intro.mve",
-    "elder.mve",
-    "vsuit.mve",
-    "afailed.mve",
-    "adestroy.mve",
-    "car.mve",
-    "cartucci.mve",
-    "timeout.mve",
-    "tanker.mve",
-    "enclave.mve",
-    "derrick.mve",
-    "artimer1.mve",
-    "artimer2.mve",
-    "artimer3.mve",
-    "artimer4.mve",
+static const char *gMovieFileNames[MOVIE_COUNT] = {
+    "iplogo.mve",   "intro.mve",    "elder.mve",    "vsuit.mve",
+    "afailed.mve",  "adestroy.mve", "car.mve",      "cartucci.mve",
+    "timeout.mve",  "tanker.mve",   "enclave.mve",  "derrick.mve",
+    "artimer1.mve", "artimer2.mve", "artimer3.mve", "artimer4.mve",
     "credits.mve",
 };
 
 // 0x518DE4
-static const char* gMoviePaletteFilePaths[MOVIE_COUNT] = {
+static const char *gMoviePaletteFilePaths[MOVIE_COUNT] = {
     nullptr,
     "art\\cuts\\introsub.pal",
     "art\\cuts\\eldersub.pal",
@@ -84,8 +72,7 @@ static char gGameMovieSubtitlesFilePath[COMPAT_MAX_PATH];
 
 // gmovie_init
 // 0x44E5C0
-int gameMoviesInit()
-{
+int gameMoviesInit() {
     int v1 = 0;
     if (backgroundSoundIsEnabled()) {
         v1 = backgroundSoundGetVolume();
@@ -104,8 +91,7 @@ int gameMoviesInit()
 }
 
 // 0x44E60C
-void gameMoviesReset()
-{
+void gameMoviesReset() {
     memset(gGameMoviesSeen, 0, sizeof(gGameMoviesSeen));
 
     gGameMovieIsPlaying = false;
@@ -113,9 +99,9 @@ void gameMoviesReset()
 }
 
 // 0x44E638
-int gameMoviesLoad(File* stream)
-{
-    if (fileRead(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
+int gameMoviesLoad(File *stream) {
+    if (fileRead(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT,
+                 stream) != MOVIE_COUNT) {
         return -1;
     }
 
@@ -123,9 +109,9 @@ int gameMoviesLoad(File* stream)
 }
 
 // 0x44E664
-int gameMoviesSave(File* stream)
-{
-    if (fileWrite(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
+int gameMoviesSave(File *stream) {
+    if (fileWrite(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT,
+                  stream) != MOVIE_COUNT) {
         return -1;
     }
 
@@ -134,30 +120,32 @@ int gameMoviesSave(File* stream)
 
 // gmovie_play
 // 0x44E690
-int gameMoviePlay(int movie, int flags)
-{
+int gameMoviePlay(int movie, int flags) {
     gGameMovieIsPlaying = true;
 
-    const char* movieFileName = gMovieFileNames[movie];
+    const char *movieFileName = gMovieFileNames[movie];
     debugPrint("\nPlaying movie: %s\n", movieFileName);
 
-    const char* language = settings.system.language.c_str();
+    const char *language = settings.system.language.c_str();
     char movieFilePath[COMPAT_MAX_PATH];
     int movieFileSize;
     bool movieFound = false;
 
     if (compat_stricmp(language, ENGLISH) != 0) {
-        snprintf(movieFilePath, sizeof(movieFilePath), "art\\%s\\cuts\\%s", language, gMovieFileNames[movie]);
+        snprintf(movieFilePath, sizeof(movieFilePath), "art\\%s\\cuts\\%s",
+                 language, gMovieFileNames[movie]);
         movieFound = dbGetFileSize(movieFilePath, &movieFileSize) == 0;
     }
 
     if (!movieFound) {
-        snprintf(movieFilePath, sizeof(movieFilePath), "art\\cuts\\%s", gMovieFileNames[movie]);
+        snprintf(movieFilePath, sizeof(movieFilePath), "art\\cuts\\%s",
+                 gMovieFileNames[movie]);
         movieFound = dbGetFileSize(movieFilePath, &movieFileSize) == 0;
     }
 
     if (!movieFound) {
-        debugPrint("\ngmovie_play() - Error: Unable to open %s\n", gMovieFileNames[movie]);
+        debugPrint("\ngmovie_play() - Error: Unable to open %s\n",
+                   gMovieFileNames[movie]);
         gGameMovieIsPlaying = false;
         return -1;
     }
@@ -177,19 +165,13 @@ int gameMoviePlay(int movie, int flags)
     int movieWindowWidth = screenWidth;
     int movieWindowHeight = screenHeight;
 
-    int win = windowCreate(
-        movieWindowX,
-        movieWindowY,
-        movieWindowWidth,
-        movieWindowHeight,
-        0,
-        WINDOW_MODAL);
+    int win = windowCreate(movieWindowX, movieWindowY, movieWindowWidth,
+                           movieWindowHeight, 0, WINDOW_MODAL);
 
     if (win == -1) {
         gGameMovieIsPlaying = false;
         return -1;
     }
-
 
     if ((flags & GAME_MOVIE_STOP_MUSIC) != 0) {
         backgroundSoundDelete();
@@ -202,7 +184,8 @@ int gameMoviePlay(int movie, int flags)
     bool subtitlesEnabled = settings.preferences.subtitles;
     int v1 = 4;
     if (subtitlesEnabled) {
-        char* subtitlesFilePath = gameMovieBuildSubtitlesFilePath(movieFilePath);
+        char *subtitlesFilePath =
+            gameMovieBuildSubtitlesFilePath(movieFilePath);
 
         int subtitlesFileSize;
         if (dbGetFileSize(subtitlesFilePath, &subtitlesFileSize) == 0) {
@@ -217,7 +200,7 @@ int gameMoviePlay(int movie, int flags)
     int oldTextColor;
     int oldFont;
     if (subtitlesEnabled) {
-        const char* subtitlesPaletteFilePath;
+        const char *subtitlesPaletteFilePath;
         if (gMoviePaletteFilePaths[movie] != nullptr) {
             subtitlesPaletteFilePath = gMoviePaletteFilePaths[movie];
         } else {
@@ -254,7 +237,8 @@ int gameMoviePlay(int movie, int flags)
     int v11 = 0;
     int buttons;
     do {
-        if (!_moviePlaying() || _game_user_wants_to_quit || inputGetInput() != -1) {
+        if (!_moviePlaying() || _game_user_wants_to_quit ||
+            inputGetInput() != -1) {
             break;
         }
 
@@ -268,7 +252,8 @@ int gameMoviePlay(int movie, int flags)
         _mouse_get_raw_state(&x, &y, &buttons);
 
         v11 |= buttons;
-    } while (((v11 & 1) == 0 && (v11 & 2) == 0) || (buttons & 1) != 0 || (buttons & 2) != 0);
+    } while (((v11 & 1) == 0 && (v11 & 2) == 0) || (buttons & 1) != 0 ||
+             (buttons & 2) != 0);
 
     _movieStop();
     _moviefx_stop();
@@ -290,7 +275,8 @@ int gameMoviePlay(int movie, int flags)
 
         windowSetFont(oldFont);
 
-        float r = (float)((Color2RGB(oldTextColor) & 0x7C00) >> 10) * flt_50352A;
+        float r =
+            (float)((Color2RGB(oldTextColor) & 0x7C00) >> 10) * flt_50352A;
         float g = (float)((Color2RGB(oldTextColor) & 0x3E0) >> 5) * flt_50352A;
         float b = (float)(Color2RGB(oldTextColor) & 0x1F) * flt_50352A;
         windowSetTextColor(r, g, b);
@@ -320,8 +306,7 @@ int gameMoviePlay(int movie, int flags)
 }
 
 // 0x44EAE4
-void gameMovieFadeOut()
-{
+void gameMovieFadeOut() {
     if (gGameMovieFaded) {
         paletteFadeTo(_cmap);
         gGameMovieFaded = false;
@@ -329,35 +314,30 @@ void gameMovieFadeOut()
 }
 
 // 0x44EB04
-bool gameMovieIsSeen(int movie)
-{
-    return gGameMoviesSeen[movie] == 1;
-}
+bool gameMovieIsSeen(int movie) { return gGameMoviesSeen[movie] == 1; }
 
 // 0x44EB14
-bool gameMovieIsPlaying()
-{
-    return gGameMovieIsPlaying;
-}
+bool gameMovieIsPlaying() { return gGameMovieIsPlaying; }
 
 // 0x44EB1C
-static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath)
-{
-    char* path = movieFilePath;
+static char *gameMovieBuildSubtitlesFilePath(char *movieFilePath) {
+    char *path = movieFilePath;
 
-    char* separator = strrchr(path, '\\');
+    char *separator = strrchr(path, '\\');
     if (separator != nullptr) {
         path = separator + 1;
     }
 
-    snprintf(gGameMovieSubtitlesFilePath, sizeof(gGameMovieSubtitlesFilePath), "text\\%s\\cuts\\%s", settings.system.language.c_str(), path);
+    snprintf(gGameMovieSubtitlesFilePath, sizeof(gGameMovieSubtitlesFilePath),
+             "text\\%s\\cuts\\%s", settings.system.language.c_str(), path);
 
-    char* pch = strrchr(gGameMovieSubtitlesFilePath, '.');
+    char *pch = strrchr(gGameMovieSubtitlesFilePath, '.');
     if (*pch != '\0') {
         *pch = '\0';
     }
 
-    strcpy(gGameMovieSubtitlesFilePath + strlen(gGameMovieSubtitlesFilePath), ".SVE");
+    strcpy(gGameMovieSubtitlesFilePath + strlen(gGameMovieSubtitlesFilePath),
+           ".SVE");
 
     return gGameMovieSubtitlesFilePath;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -60,9 +60,6 @@ static void _main_death_voiceover_callback();
 static int _mainDeathGrabTextFile(const char* fileName, char* dest);
 static int _mainDeathWordWrap(char* text, int width, short* beginnings, short* count);
 
-extern void* internal_malloc(size_t size);
-extern void internal_free(void* ptr);
-
 // 0x5194C8
 static char _mainMap[] = "artemple.map";
 
@@ -428,7 +425,7 @@ static void showDeath() {
         }
 
         // Allocate memory for the scaled image.
-        unsigned char* scaled = reinterpret_cast<unsigned char*>(internal_malloc((scaledWidth + 1) * (scaledHeight + 1)));
+        unsigned char* scaled = reinterpret_cast<unsigned char*>(SDL_malloc((scaledWidth + 1) * (scaledHeight + 1)));
         if (scaled != nullptr) {
             // Perform stretching.
             blitBufferToBufferStretch(deathData, deathScreenWidth, deathScreenHeight, deathScreenWidth, scaled, scaledWidth, scaledHeight, scaledWidth);

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,6 +23,7 @@
 #include "mainmenu.h"
 #include "map.h"
 #include "mouse.h"
+#include "movie.h"
 #include "object.h"
 #include "palette.h"
 #include "platform_compat.h"
@@ -40,25 +41,24 @@
 #include "window_manager_private.h"
 #include "word_wrap.h"
 #include "worldmap.h"
-#include "movie.h"
-
 
 namespace fallout {
 
 #define DEATH_WINDOW_WIDTH 640
 #define DEATH_WINDOW_HEIGHT 480
 
-static bool falloutInit(int argc, char** argv);
+static bool falloutInit(int argc, char **argv);
 static int main_reset_system();
 static void main_exit_system();
-static int _main_load_new(char* fname);
+static int _main_load_new(char *fname);
 static int main_loadgame_new();
 static void main_unload_new();
 static void mainLoop();
 static void showDeath();
 static void _main_death_voiceover_callback();
-static int _mainDeathGrabTextFile(const char* fileName, char* dest);
-static int _mainDeathWordWrap(char* text, int width, short* beginnings, short* count);
+static int _mainDeathGrabTextFile(const char *fileName, char *dest);
+static int _mainDeathWordWrap(char *text, int width, short *beginnings,
+                              short *count);
 
 // 0x5194C8
 static char _mainMap[] = "artemple.map";
@@ -73,8 +73,7 @@ static bool _main_show_death_scene = false;
 static bool _main_death_voiceover_done;
 
 // 0x48099C
-int falloutMain(int argc, char** argv)
-{
+int falloutMain(int argc, char **argv) {
     if (!autorunMutexCreate()) {
         return 1;
     }
@@ -82,13 +81,14 @@ int falloutMain(int argc, char** argv)
     if (!falloutInit(argc, argv)) {
         return 1;
     }
-    
+
     // added for movie stretching
     readMovieSettings();
 
     // SFALL: Allow to skip intro movies
     int skipOpeningMovies;
-    configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_SKIP_OPENING_MOVIES_KEY, &skipOpeningMovies);
+    configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
+                 SFALL_CONFIG_SKIP_OPENING_MOVIES_KEY, &skipOpeningMovies);
     if (skipOpeningMovies < 1) {
         gameMoviePlay(MOVIE_IPLOGO, GAME_MOVIE_FADE_IN);
         gameMoviePlay(MOVIE_INTRO, 0);
@@ -120,14 +120,17 @@ int falloutMain(int argc, char** argv)
                     randomSeedPrerandom(-1);
 
                     // SFALL: Override starting map.
-                    char* mapName = nullptr;
-                    if (configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_STARTING_MAP_KEY, &mapName)) {
+                    char *mapName = nullptr;
+                    if (configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
+                                        SFALL_CONFIG_STARTING_MAP_KEY,
+                                        &mapName)) {
                         if (*mapName == '\0') {
                             mapName = nullptr;
                         }
                     }
 
-                    char* mapNameCopy = compat_strdup(mapName != nullptr ? mapName : _mainMap);
+                    char *mapNameCopy =
+                        compat_strdup(mapName != nullptr ? mapName : _mainMap);
                     _main_load_new(mapNameCopy);
                     free(mapNameCopy);
 
@@ -154,7 +157,9 @@ int falloutMain(int argc, char** argv)
                 break;
             case MAIN_MENU_LOAD_GAME:
                 if (1) {
-                    int win = windowCreate(0, 0, screenGetWidth(), screenGetHeight(), _colorTable[0], WINDOW_MODAL | WINDOW_MOVE_ON_TOP);
+                    int win = windowCreate(0, 0, screenGetWidth(),
+                                           screenGetHeight(), _colorTable[0],
+                                           WINDOW_MODAL | WINDOW_MOVE_ON_TOP);
                     mainMenuWindowHide(true);
                     mainMenuWindowFree();
 
@@ -233,8 +238,7 @@ int falloutMain(int argc, char** argv)
 }
 
 // 0x480CC0
-static bool falloutInit(int argc, char** argv)
-{
+static bool falloutInit(int argc, char **argv) {
     if (gameInitWithOptions("FALLOUT II", false, 0, 0, argc, argv) == -1) {
         return false;
     }
@@ -245,8 +249,7 @@ static bool falloutInit(int argc, char** argv)
 // NOTE: Inlined.
 //
 // 0x480D0C
-static int main_reset_system()
-{
+static int main_reset_system() {
     gameReset();
 
     return 1;
@@ -255,23 +258,22 @@ static int main_reset_system()
 // NOTE: Inlined.
 //
 // 0x480D18
-static void main_exit_system()
-{
+static void main_exit_system() {
     backgroundSoundDelete();
 
     gameExit();
 }
 
 // 0x480D4C
-static int _main_load_new(char* mapFileName)
-{
+static int _main_load_new(char *mapFileName) {
     _game_user_wants_to_quit = 0;
     _main_show_death_scene = 0;
     gDude->flags &= ~OBJECT_FLAT;
     objectShow(gDude, nullptr);
     mouseHideCursor();
 
-    int win = windowCreate(0, 0, screenGetWidth(), screenGetHeight(), _colorTable[0], WINDOW_MODAL | WINDOW_MOVE_ON_TOP);
+    int win = windowCreate(0, 0, screenGetWidth(), screenGetHeight(),
+                           _colorTable[0], WINDOW_MODAL | WINDOW_MOVE_ON_TOP);
     windowRefresh(win);
 
     colorPaletteLoad("color.pal");
@@ -291,8 +293,7 @@ static int _main_load_new(char* mapFileName)
 // NOTE: Inlined.
 //
 // 0x480DF8
-static int main_loadgame_new()
-{
+static int main_loadgame_new() {
     _game_user_wants_to_quit = 0;
     _main_show_death_scene = 0;
 
@@ -310,15 +311,13 @@ static int main_loadgame_new()
 }
 
 // 0x480E34
-static void main_unload_new()
-{
+static void main_unload_new() {
     objectHide(gDude, nullptr);
     _map_exit();
 }
 
 // 0x480E48
-static void mainLoop()
-{
+static void mainLoop() {
     bool cursorWasHidden = cursorIsHidden();
     if (cursorWasHidden) {
         mouseShowCursor();
@@ -346,7 +345,8 @@ static void mainLoop()
             _main_game_paused = 0;
         }
 
-        if ((gDude->data.critter.combat.results & (DAM_DEAD | DAM_KNOCKED_OUT)) != 0) {
+        if ((gDude->data.critter.combat.results &
+             (DAM_DEAD | DAM_KNOCKED_OUT)) != 0) {
             endgameSetupDeathEnding(ENDGAME_DEATH_ENDING_REASON_DEATH);
             _main_show_death_scene = 1;
             _game_user_wants_to_quit = 2;
@@ -379,7 +379,8 @@ static void showDeath() {
     Config config;
     if (configInit(&config)) {
         if (configRead(&config, "f2_res.ini", false)) {
-            configGetInt(&config, "STATIC_SCREENS", "DEATH_SCRN_SIZE", &deathScreenStretchMode);
+            configGetInt(&config, "STATIC_SCREENS", "DEATH_SCRN_SIZE",
+                         &deathScreenStretchMode);
         }
         configFree(&config);
     }
@@ -396,16 +397,17 @@ static void showDeath() {
     }
 
     // Get pointer to the death screen pixel data.
-    unsigned char* deathData = deathFrmImage.getData();
+    unsigned char *deathData = deathFrmImage.getData();
     int deathScreenWidth = DEATH_WINDOW_WIDTH;
     int deathScreenHeight = DEATH_WINDOW_HEIGHT;
 
-    unsigned char* finalBuffer = deathData;
+    unsigned char *finalBuffer = deathData;
     int finalWidth = deathScreenWidth;
     int finalHeight = deathScreenHeight;
 
     // Handle optional stretching if needed.
-    if (deathScreenStretchMode != 0 || screenWidth < deathScreenWidth || screenHeight < deathScreenHeight) {
+    if (deathScreenStretchMode != 0 || screenWidth < deathScreenWidth ||
+        screenHeight < deathScreenHeight) {
         int scaledWidth;
         int scaledHeight;
 
@@ -415,29 +417,42 @@ static void showDeath() {
             scaledHeight = screenHeight;
         } else {
             // Scale while maintaining aspect ratio for setting 1.
-            if (screenHeight * deathScreenWidth >= screenWidth * deathScreenHeight) {
+            if (screenHeight * deathScreenWidth >=
+                screenWidth * deathScreenHeight) {
                 scaledWidth = screenWidth;
-                scaledHeight = (screenWidth * deathScreenHeight + (deathScreenWidth)) / deathScreenWidth;
+                scaledHeight =
+                    (screenWidth * deathScreenHeight + (deathScreenWidth)) /
+                    deathScreenWidth;
             } else {
-                scaledWidth = (screenHeight * deathScreenWidth + (deathScreenHeight)) / deathScreenHeight;
+                scaledWidth =
+                    (screenHeight * deathScreenWidth + (deathScreenHeight)) /
+                    deathScreenHeight;
                 scaledHeight = screenHeight;
             }
         }
 
         // Allocate memory for the scaled image.
-        unsigned char* scaled = reinterpret_cast<unsigned char*>(SDL_malloc((scaledWidth + 1) * (scaledHeight + 1)));
+        unsigned char *scaled = reinterpret_cast<unsigned char *>(
+            SDL_malloc((scaledWidth + 1) * (scaledHeight + 1)));
         if (scaled != nullptr) {
             // Perform stretching.
-            blitBufferToBufferStretch(deathData, deathScreenWidth, deathScreenHeight, deathScreenWidth, scaled, scaledWidth, scaledHeight, scaledWidth);
-            
-            // Fix rightmost edge artifacts by copying the last good pixel horizontally.
+            blitBufferToBufferStretch(deathData, deathScreenWidth,
+                                      deathScreenHeight, deathScreenWidth,
+                                      scaled, scaledWidth, scaledHeight,
+                                      scaledWidth);
+
+            // Fix rightmost edge artifacts by copying the last good pixel
+            // horizontally.
             for (int y = 0; y < scaledHeight; y++) {
-                scaled[y * scaledWidth + (scaledWidth - 1)] = scaled[y * scaledWidth + (scaledWidth - 2)];
+                scaled[y * scaledWidth + (scaledWidth - 1)] =
+                    scaled[y * scaledWidth + (scaledWidth - 2)];
             }
 
-            // Fix bottom row artifacts by copying the last good pixel vertically.
+            // Fix bottom row artifacts by copying the last good pixel
+            // vertically.
             for (int x = 0; x < scaledWidth; x++) {
-                scaled[(scaledHeight - 1) * scaledWidth + x] = scaled[(scaledHeight - 2) * scaledWidth + x];
+                scaled[(scaledHeight - 1) * scaledWidth + x] =
+                    scaled[(scaledHeight - 2) * scaledWidth + x];
             }
 
             finalBuffer = scaled;
@@ -449,11 +464,12 @@ static void showDeath() {
     // Center the death window on screen.
     int windowX = (screenWidth - finalWidth) / 2;
     int windowY = (screenHeight - finalHeight) / 2;
-    int win = windowCreate(windowX, windowY, finalWidth, finalHeight, 0, WINDOW_MOVE_ON_TOP);
+    int win = windowCreate(windowX, windowY, finalWidth, finalHeight, 0,
+                           WINDOW_MOVE_ON_TOP);
 
     if (win != -1) {
         do {
-            unsigned char* windowBuffer = windowGetBuffer(win);
+            unsigned char *windowBuffer = windowGetBuffer(win);
             if (windowBuffer == nullptr) {
                 break;
             }
@@ -469,11 +485,12 @@ static void showDeath() {
             inputEventQueueReset();
 
             // Draw death image to window.
-            blitBufferToBuffer(finalBuffer, finalWidth, finalHeight, finalWidth, windowBuffer, finalWidth);
+            blitBufferToBuffer(finalBuffer, finalWidth, finalHeight, finalWidth,
+                               windowBuffer, finalWidth);
             deathFrmImage.unlock();
 
             // Get death ending filename.
-            const char* deathFileName = endgameDeathEndingGetFileName();
+            const char *deathFileName = endgameDeathEndingGetFileName();
 
             // If subtitles are enabled, load and display them.
             if (settings.preferences.subtitles) {
@@ -485,13 +502,15 @@ static void showDeath() {
                     short lineCount;
 
                     // Set subtitle box width based on final screen width.
-                    int subtitleWidth = (finalWidth >= 640) ? 560 : finalWidth - 80;
+                    int subtitleWidth =
+                        (finalWidth >= 640) ? 560 : finalWidth - 80;
                     if (subtitleWidth < 100) {
                         subtitleWidth = finalWidth - 20;
                     }
 
                     // Word wrap subtitle text.
-                    if (_mainDeathWordWrap(text, subtitleWidth, lineStartOffsets, &lineCount) == 0) {
+                    if (_mainDeathWordWrap(text, subtitleWidth,
+                                           lineStartOffsets, &lineCount) == 0) {
                         int lineHeight = fontGetLineHeight();
                         int subtitleHeight = lineHeight * lineCount + 2;
 
@@ -499,13 +518,18 @@ static void showDeath() {
                         int subtitleX = (finalWidth - subtitleWidth) / 2;
                         int subtitleY = finalHeight - subtitleHeight - 8;
 
-                        unsigned char* subtitleBuffer = windowBuffer + finalWidth * subtitleY + subtitleX;
+                        unsigned char *subtitleBuffer =
+                            windowBuffer + finalWidth * subtitleY + subtitleX;
 
-                        bufferFill(subtitleBuffer - finalWidth * 1, subtitleWidth, subtitleHeight, finalWidth, 0);
+                        bufferFill(subtitleBuffer - finalWidth * 1,
+                                   subtitleWidth, subtitleHeight, finalWidth,
+                                   0);
 
                         // Draw each subtitle line.
                         for (int i = 0; i < lineCount; i++) {
-                            fontDrawText(subtitleBuffer, text + lineStartOffsets[i], subtitleWidth, finalWidth, _colorTable[32767]);
+                            fontDrawText(
+                                subtitleBuffer, text + lineStartOffsets[i],
+                                subtitleWidth, finalWidth, _colorTable[32767]);
                             subtitleBuffer += finalWidth * lineHeight;
                         }
                     }
@@ -539,7 +563,8 @@ static void showDeath() {
                 keyCode = inputGetInput();
                 renderPresent();
                 sharedFpsLimiter.throttle();
-            } while (keyCode == -1 && !_main_death_voiceover_done && getTicksSince(startTime) < delay);
+            } while (keyCode == -1 && !_main_death_voiceover_done &&
+                     getTicksSince(startTime) < delay);
 
             // Clean up voiceover.
             speechSetEndCallback(nullptr);
@@ -576,25 +601,24 @@ static void showDeath() {
 }
 
 // 0x4814A8
-static void _main_death_voiceover_callback()
-{
+static void _main_death_voiceover_callback() {
     _main_death_voiceover_done = true;
 }
 
 // Read endgame subtitle.
 //
 // 0x4814B4
-static int _mainDeathGrabTextFile(const char* fileName, char* dest)
-{
-    const char* p = strrchr(fileName, '\\');
+static int _mainDeathGrabTextFile(const char *fileName, char *dest) {
+    const char *p = strrchr(fileName, '\\');
     if (p == nullptr) {
         return -1;
     }
 
     char path[COMPAT_MAX_PATH];
-    snprintf(path, sizeof(path), "text\\%s\\cuts\\%s%s", settings.system.language.c_str(), p + 1, ".TXT");
+    snprintf(path, sizeof(path), "text\\%s\\cuts\\%s%s",
+             settings.system.language.c_str(), p + 1, ".TXT");
 
-    File* stream = fileOpen(path, "rt");
+    File *stream = fileOpen(path, "rt");
     if (stream == nullptr) {
         return -1;
     }
@@ -620,10 +644,10 @@ static int _mainDeathGrabTextFile(const char* fileName, char* dest)
 }
 
 // 0x481598
-static int _mainDeathWordWrap(char* text, int width, short* beginnings, short* count)
-{
+static int _mainDeathWordWrap(char *text, int width, short *beginnings,
+                              short *count) {
     while (true) {
-        char* sep = strchr(text, ':');
+        char *sep = strchr(text, ':');
         if (sep == nullptr) {
             break;
         }
@@ -643,7 +667,7 @@ static int _mainDeathWordWrap(char* text, int width, short* beginnings, short* c
     *count -= 1;
 
     for (int index = 1; index < *count; index++) {
-        char* p = text + beginnings[index];
+        char *p = text + beginnings[index];
         while (p >= text && *p != ' ') {
             p--;
             beginnings[index]--;

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -224,22 +224,22 @@ static void movieDirectImpl(
     int sizeMode = movieGetSizeFlag(); // Gets scaling mode (original, aspect, fullscreen) from f2_res.ini
     bool subtitlesEnabled = settings.preferences.subtitles;
 
-    // Adds bottom margin if subtitles are enabled and playing in fullscreen mode
-    float subtitleMarginRatio =
-        (_movieHasSubtitles && sizeMode == MOVIE_SIZE_FULLSCREEN && subtitlesEnabled)
-            ? 0.15f : 0.0f;
+    // Figure out if we should reserve vertical margin for subtitles
+    float subtitleMarginRatio = (_movieHasSubtitles && subtitlesEnabled) ? 0.15f : 0.0f;
 
     // Adjust final size based on scaling mode
     if (sizeMode == MOVIE_SIZE_ASPECT) {
-        // Keep aspect ratio
-        float scale = fminf((float)windowWidth / srcWidth, (float)windowHeight / srcHeight);
+        // Reserve margin for subtitles even in aspect mode (margin may be zero)
+        float availableHeight = (float)windowHeight * (1.0f - subtitleMarginRatio);
+        float scale = fminf((float)windowWidth / srcWidth, availableHeight / srcHeight);
         finalWidth = (int)(srcWidth * scale);
         finalHeight = (int)(srcHeight * scale);
     } else if (sizeMode == MOVIE_SIZE_FULLSCREEN) {
-        // Fullscreen, with optional vertical margin for subtitles
+        // Fullscreen with margin for subtitles (margin may be zero)
         finalWidth = windowWidth;
         finalHeight = (int)(windowHeight * (1.0f - subtitleMarginRatio));
     }
+
 
     // buffer for rescaled image
     unsigned char* scaledFrame = (unsigned char*)internal_malloc_safe(finalWidth * finalHeight, __FILE__, __LINE__);

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -30,27 +30,36 @@ namespace fallout {
 
 typedef struct MovieSubtitleListNode {
     int num;
-    char* text;
-    struct MovieSubtitleListNode* next;
+    char *text;
+    struct MovieSubtitleListNode *next;
 } MovieSubtitleListNode;
 
-static void* movieMallocImpl(size_t size);
-static void movieFreeImpl(void* ptr);
-static bool movieReadImpl(void* handle, void* buf, int count);
-static void movieDirectImpl(unsigned char* pixels, int src_width, int src_height, int src_x, int src_y, int dst_width, int dst_height, int dst_x, int dst_y);
-static int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int pitch);
-static int _movieScaleSubRectAlpha(int win, unsigned char* data, int width, int height, int pitch);
-static int _movieScaleWindowAlpha(int win, unsigned char* data, int width, int height, int pitch);
-static int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch);
-static int _movieScaleWindow(int win, unsigned char* data, int width, int height, int pitch);
-static int _blitNormal(int win, unsigned char* data, int width, int height, int pitch);
-static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int end);
+static void *movieMallocImpl(size_t size);
+static void movieFreeImpl(void *ptr);
+static bool movieReadImpl(void *handle, void *buf, int count);
+static void movieDirectImpl(unsigned char *pixels, int src_width,
+                            int src_height, int src_x, int src_y, int dst_width,
+                            int dst_height, int dst_x, int dst_y);
+static int _movieScaleSubRect(int win, unsigned char *data, int width,
+                              int height, int pitch);
+static int _movieScaleSubRectAlpha(int win, unsigned char *data, int width,
+                                   int height, int pitch);
+static int _movieScaleWindowAlpha(int win, unsigned char *data, int width,
+                                  int height, int pitch);
+static int _blitAlpha(int win, unsigned char *data, int width, int height,
+                      int pitch);
+static int _movieScaleWindow(int win, unsigned char *data, int width,
+                             int height, int pitch);
+static int _blitNormal(int win, unsigned char *data, int width, int height,
+                       int pitch);
+static void movieSetPaletteEntriesImpl(unsigned char *palette, int start,
+                                       int end);
 static void _cleanupMovie(int a1);
 static void _cleanupLast();
-static File* movieOpen(char* filePath);
-static void movieLoadSubtitles(char* filePath);
+static File *movieOpen(char *filePath);
+static void movieLoadSubtitles(char *filePath);
 static void movieRenderSubtitles();
-static int _movieStart(int win, char* filePath);
+static int _movieStart(int win, char *filePath);
 static bool _localMovieCallback();
 static int _stepMovie();
 
@@ -64,7 +73,8 @@ static int gMovieWindow = -1;
 static int gMovieSubtitlesFont = -1;
 
 // 0x5195E0
-static MovieSetPaletteEntriesProc* gMovieSetPaletteEntriesProc = _setSystemPaletteEntries;
+static MovieSetPaletteEntriesProc *gMovieSetPaletteEntriesProc =
+    _setSystemPaletteEntries;
 
 // 0x5195E4
 static int gMovieSubtitlesColorR = 31;
@@ -85,10 +95,10 @@ static Rect _movieRect;
 static void (*_movieCallback)();
 
 // 0x638E38
-static MovieSetPaletteProc* gMoviePaletteProc;
+static MovieSetPaletteProc *gMoviePaletteProc;
 
 // 0x638E40
-static MovieBuildSubtitleFilePathProc* gMovieBuildSubtitleFilePathProc;
+static MovieBuildSubtitleFilePathProc *gMovieBuildSubtitleFilePathProc;
 
 // 0x638E48
 static int _subtitleW;
@@ -118,7 +128,7 @@ static int _lastMovieX;
 static int _lastMovieY;
 
 // 0x638E74
-static MovieSubtitleListNode* gMovieSubtitleHead;
+static MovieSubtitleListNode *gMovieSubtitleHead;
 
 // 0x638E78
 static unsigned int gMovieFlags;
@@ -136,7 +146,7 @@ static int _movieH;
 static int _movieOffset;
 
 // 0x638E90
-static unsigned char* _lastMovieBuffer;
+static unsigned char *_lastMovieBuffer;
 
 // 0x638E94
 static int _movieW;
@@ -148,10 +158,10 @@ static int _subtitleH;
 static int _running;
 
 // 0x638EA8
-static File* gMovieFileStream;
+static File *gMovieFileStream;
 
 // 0x638EAC
-static unsigned char* _alphaWindowBuf;
+static unsigned char *_alphaWindowBuf;
 
 // 0x638EB0
 static int _movieX;
@@ -160,19 +170,18 @@ static int _movieX;
 static int _movieY;
 
 // 0x638EBC
-static File* _alphaHandle;
+static File *_alphaHandle;
 
 // 0x638EC0
-static unsigned char* _alphaBuf;
+static unsigned char *_alphaBuf;
 
-static unsigned char* MVE_lastBuffer = nullptr;
+static unsigned char *MVE_lastBuffer = nullptr;
 
 // Added for movie stretching
 static int _movieSizeFlag = 0; // private to movie.cc
 
 // Added for movie stretching
-void readMovieSettings()
-{
+void readMovieSettings() {
     int size = 0;
     Config config;
     if (configInit(&config)) {
@@ -186,52 +195,50 @@ void readMovieSettings()
 }
 
 // Added for movie stretching
-int movieGetSizeFlag()
-{
-    return _movieSizeFlag;
-}
+int movieGetSizeFlag() { return _movieSizeFlag; }
 
 // 0x4865FC
-static void* movieMallocImpl(size_t size)
-{
-    return internal_malloc_safe(size, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 209
+static void *movieMallocImpl(size_t size) {
+    return internal_malloc_safe(size, __FILE__,
+                                __LINE__); // "..\\int\\MOVIE.C", 209
 }
 
 // 0x486614
-static void movieFreeImpl(void* ptr)
-{
+static void movieFreeImpl(void *ptr) {
     internal_free_safe(ptr, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 213
 }
 
 // 0x48662C
-static bool movieReadImpl(void* handle, void* buf, int count)
-{
-    return fileRead(buf, 1, count, (File*)handle) == count;
+static bool movieReadImpl(void *handle, void *buf, int count) {
+    return fileRead(buf, 1, count, (File *)handle) == count;
 }
 
 // 0x486654
-// Renders the movie frame directly to the screen, with optional scaling and subtitle margins.
-static void movieDirectImpl(
-    unsigned char* pixels, int srcWidth, int srcHeight,
-    int srcX, int srcY, int dstWidth, int dstHeight,
-    int dstX, int dstY)
-{
+// Renders the movie frame directly to the screen, with optional scaling and
+// subtitle margins.
+static void movieDirectImpl(unsigned char *pixels, int srcWidth, int srcHeight,
+                            int srcX, int srcY, int dstWidth, int dstHeight,
+                            int dstX, int dstY) {
     int windowWidth = screenGetWidth();
     int windowHeight = screenGetHeight();
 
     int finalWidth = srcWidth;
     int finalHeight = srcHeight;
-    int sizeMode = movieGetSizeFlag(); // Gets scaling mode (original, aspect, fullscreen) from f2_res.ini
+    int sizeMode = movieGetSizeFlag(); // Gets scaling mode (original, aspect,
+                                       // fullscreen) from f2_res.ini
     bool subtitlesEnabled = settings.preferences.subtitles;
 
     // Figure out if we should reserve vertical margin for subtitles
-    float subtitleMarginRatio = (_movieHasSubtitles && subtitlesEnabled) ? 0.15f : 0.0f;
+    float subtitleMarginRatio =
+        (_movieHasSubtitles && subtitlesEnabled) ? 0.15f : 0.0f;
 
     // Adjust final size based on scaling mode
     if (sizeMode == MOVIE_SIZE_ASPECT) {
         // Reserve margin for subtitles even in aspect mode (margin may be zero)
-        float availableHeight = (float)windowHeight * (1.0f - subtitleMarginRatio);
-        float scale = fminf((float)windowWidth / srcWidth, availableHeight / srcHeight);
+        float availableHeight =
+            (float)windowHeight * (1.0f - subtitleMarginRatio);
+        float scale =
+            fminf((float)windowWidth / srcWidth, availableHeight / srcHeight);
         finalWidth = (int)(srcWidth * scale);
         finalHeight = (int)(srcHeight * scale);
     } else if (sizeMode == MOVIE_SIZE_FULLSCREEN) {
@@ -240,9 +247,9 @@ static void movieDirectImpl(
         finalHeight = (int)(windowHeight * (1.0f - subtitleMarginRatio));
     }
 
-
     // buffer for rescaled image
-    unsigned char* scaledFrame = (unsigned char*)internal_malloc_safe(finalWidth * finalHeight, __FILE__, __LINE__);
+    unsigned char *scaledFrame = (unsigned char *)internal_malloc_safe(
+        finalWidth * finalHeight, __FILE__, __LINE__);
 
     // Nearest-neighbor scaling using fixed-point math
     const int fpShift = 16;
@@ -251,11 +258,13 @@ static void movieDirectImpl(
 
     for (int y = 0, ySrcFP = 0; y < finalHeight; y++, ySrcFP += yStep) {
         int srcY = ySrcFP >> fpShift;
-        if (srcY >= srcHeight) srcY = srcHeight - 1;
+        if (srcY >= srcHeight)
+            srcY = srcHeight - 1;
 
         for (int x = 0, xSrcFP = 0; x < finalWidth; x++, xSrcFP += xStep) {
             int srcX = xSrcFP >> fpShift;
-            if (srcX >= srcWidth) srcX = srcWidth - 1;
+            if (srcX >= srcWidth)
+                srcX = srcWidth - 1;
 
             scaledFrame[y * finalWidth + x] = pixels[srcY * srcWidth + srcX];
         }
@@ -266,9 +275,11 @@ static void movieDirectImpl(
     int posY = (windowHeight - finalHeight) / 2;
 
     if (sizeMode == MOVIE_SIZE_FULLSCREEN) {
-        // Fullscreen movies are normally top-left aligned unless subtitles are shown
+        // Fullscreen movies are normally top-left aligned unless subtitles are
+        // shown
         if (_movieHasSubtitles) {
-            posY = (windowHeight - finalHeight) / 2; // center vertically with margin
+            posY = (windowHeight - finalHeight) /
+                   2; // center vertically with margin
         } else {
             posY = 0;
         }
@@ -276,31 +287,30 @@ static void movieDirectImpl(
     }
 
     // Blit scaled frame to screen at final position
-    _scr_blit(
-        scaledFrame, finalWidth, finalHeight,
-        0, 0, finalWidth, finalHeight,
-        posX, posY);
+    _scr_blit(scaledFrame, finalWidth, finalHeight, 0, 0, finalWidth,
+              finalHeight, posX, posY);
 
     renderPresent();
     internal_free_safe(scaledFrame, __FILE__, __LINE__);
 
     // Store last frame properties (used elsewhere for subtitles/positioning)
     _lastMovieSX = srcX;
-        _lastMovieSY = srcY;
-        _lastMovieX = posX;
-        _lastMovieY = posY;
-        _lastMovieBH = srcHeight;
-        _lastMovieBW = srcWidth;
-        _lastMovieW = finalWidth;
-        _lastMovieH = finalHeight;
-        MVE_lastBuffer = pixels;
+    _lastMovieSY = srcY;
+    _lastMovieX = posX;
+    _lastMovieY = posY;
+    _lastMovieBH = srcHeight;
+    _lastMovieBW = srcWidth;
+    _lastMovieW = finalWidth;
+    _lastMovieH = finalHeight;
+    MVE_lastBuffer = pixels;
 }
 
 // 0x486B68
-int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _movieScaleSubRect(int win, unsigned char *data, int width, int height,
+                       int pitch) {
     int windowWidth = windowGetWidth(win);
-    unsigned char* windowBuffer = windowGetBuffer(win) + windowWidth * _movieY + _movieX;
+    unsigned char *windowBuffer =
+        windowGetBuffer(win) + windowWidth * _movieY + _movieX;
     if (width * 4 / 3 > _movieW) {
         gMovieFlags |= 0x01;
         return 0;
@@ -315,7 +325,7 @@ int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int 
             value |= data[2] << 16;
             value |= data[2] << 24;
 
-            *(unsigned int*)windowBuffer = value;
+            *(unsigned int *)windowBuffer = value;
 
             windowBuffer += 4;
             data += 3;
@@ -333,38 +343,38 @@ int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int 
 }
 
 // 0x486C74
-int _movieScaleSubRectAlpha(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _movieScaleSubRectAlpha(int win, unsigned char *data, int width, int height,
+                            int pitch) {
     gMovieFlags |= 1;
     return 0;
 }
 
 // NOTE: Uncollapsed 0x486C74.
-int _movieScaleWindowAlpha(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _movieScaleWindowAlpha(int win, unsigned char *data, int width, int height,
+                           int pitch) {
     gMovieFlags |= 1;
     return 0;
 }
 
 // 0x486C80
-int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _blitAlpha(int win, unsigned char *data, int width, int height, int pitch) {
     int windowWidth = windowGetWidth(win);
-    unsigned char* windowBuffer = windowGetBuffer(win);
-    _alphaBltBuf(data, width, height, pitch, _alphaWindowBuf, _alphaBuf, windowBuffer + windowWidth * _movieY + _movieX, windowWidth);
+    unsigned char *windowBuffer = windowGetBuffer(win);
+    _alphaBltBuf(data, width, height, pitch, _alphaWindowBuf, _alphaBuf,
+                 windowBuffer + windowWidth * _movieY + _movieX, windowWidth);
     return 1;
 }
 
 // 0x486CD4
-int _movieScaleWindow(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _movieScaleWindow(int win, unsigned char *data, int width, int height,
+                      int pitch) {
     int windowWidth = windowGetWidth(win);
     if (width != 3 * windowWidth / 4) {
         gMovieFlags |= 1;
         return 0;
     }
 
-    unsigned char* windowBuffer = windowGetBuffer(win);
+    unsigned char *windowBuffer = windowGetBuffer(win);
     for (int y = 0; y < height; y++) {
         int scaledWidth = width / 3;
         for (int x = 0; x < scaledWidth; x++) {
@@ -373,7 +383,7 @@ int _movieScaleWindow(int win, unsigned char* data, int width, int height, int p
             value |= data[2] << 16;
             value |= data[3] << 24;
 
-            *(unsigned int*)windowBuffer = value;
+            *(unsigned int *)windowBuffer = value;
 
             windowBuffer += 4;
             data += 3;
@@ -385,26 +395,27 @@ int _movieScaleWindow(int win, unsigned char* data, int width, int height, int p
 }
 
 // 0x486D84
-int _blitNormal(int win, unsigned char* data, int width, int height, int pitch)
-{
+int _blitNormal(int win, unsigned char *data, int width, int height,
+                int pitch) {
     int windowWidth = windowGetWidth(win);
-    unsigned char* windowBuffer = windowGetBuffer(win);
-    _drawScaled(windowBuffer + windowWidth * _movieY + _movieX, _movieW, _movieH, windowWidth, data, width, height, pitch);
+    unsigned char *windowBuffer = windowGetBuffer(win);
+    _drawScaled(windowBuffer + windowWidth * _movieY + _movieX, _movieW,
+                _movieH, windowWidth, data, width, height, pitch);
     return 1;
 }
 
 // 0x486DDC
-static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int end)
-{
+static void movieSetPaletteEntriesImpl(unsigned char *palette, int start,
+                                       int end) {
     if (end != 0) {
-        gMovieSetPaletteEntriesProc(palette + start * 3, start, end + start - 1);
+        gMovieSetPaletteEntriesProc(palette + start * 3, start,
+                                    end + start - 1);
     }
 }
 
 // initMovie
 // 0x486E0C
-void movieInit()
-{
+void movieInit() {
     MveSetMemory(movieMallocImpl, movieFreeImpl);
     MveSetPalette(movieSetPaletteEntriesImpl);
     MveSetScreenSize(screenGetWidth(), screenGetHeight());
@@ -412,8 +423,7 @@ void movieInit()
 }
 
 // 0x486E98
-static void _cleanupMovie(int a1)
-{
+static void _cleanupMovie(int a1) {
     if (!_running) {
         return;
     }
@@ -424,12 +434,15 @@ static void _cleanupMovie(int a1)
     debugPrint("Frames %d, dropped %d\n", frame, dropped);
 
     if (_lastMovieBuffer != nullptr) {
-        internal_free_safe(_lastMovieBuffer, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 787
+        internal_free_safe(_lastMovieBuffer, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 787
         _lastMovieBuffer = nullptr;
     }
 
     if (MVE_lastBuffer != nullptr) {
-        _lastMovieBuffer = (unsigned char*)internal_malloc_safe(_lastMovieBH * _lastMovieBW, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 802
+        _lastMovieBuffer = (unsigned char *)internal_malloc_safe(
+            _lastMovieBH * _lastMovieBW, __FILE__,
+            __LINE__); // "..\\int\\MOVIE.C", 802
         memcpy(_lastMovieBuffer, MVE_lastBuffer, _lastMovieBW * _lastMovieBH);
         MVE_lastBuffer = nullptr;
     }
@@ -443,7 +456,10 @@ static void _cleanupMovie(int a1)
     fileClose(gMovieFileStream);
 
     if (_alphaWindowBuf != nullptr) {
-        blitBufferToBuffer(_alphaWindowBuf, _movieW, _movieH, _movieW, windowGetBuffer(gMovieWindow) + _movieY * windowGetWidth(gMovieWindow) + _movieX, windowGetWidth(gMovieWindow));
+        blitBufferToBuffer(_alphaWindowBuf, _movieW, _movieH, _movieW,
+                           windowGetBuffer(gMovieWindow) +
+                               _movieY * windowGetWidth(gMovieWindow) + _movieX,
+                           windowGetWidth(gMovieWindow));
         windowRefreshRect(gMovieWindow, &_movieRect);
     }
 
@@ -453,19 +469,23 @@ static void _cleanupMovie(int a1)
     }
 
     if (_alphaBuf != nullptr) {
-        internal_free_safe(_alphaBuf, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 840
+        internal_free_safe(_alphaBuf, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 840
         _alphaBuf = nullptr;
     }
 
     if (_alphaWindowBuf != nullptr) {
-        internal_free_safe(_alphaWindowBuf, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 845
+        internal_free_safe(_alphaWindowBuf, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 845
         _alphaWindowBuf = nullptr;
     }
 
     while (gMovieSubtitleHead != nullptr) {
-        MovieSubtitleListNode* next = gMovieSubtitleHead->next;
-        internal_free_safe(gMovieSubtitleHead->text, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 851
-        internal_free_safe(gMovieSubtitleHead, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 852
+        MovieSubtitleListNode *next = gMovieSubtitleHead->next;
+        internal_free_safe(gMovieSubtitleHead->text, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 851
+        internal_free_safe(gMovieSubtitleHead, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 852
         gMovieSubtitleHead = next;
     }
 
@@ -477,27 +497,25 @@ static void _cleanupMovie(int a1)
 }
 
 // 0x48711C
-void movieExit()
-{
+void movieExit() {
     _cleanupMovie(1);
 
     if (_lastMovieBuffer) {
-        internal_free_safe(_lastMovieBuffer, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 869
+        internal_free_safe(_lastMovieBuffer, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 869
         _lastMovieBuffer = nullptr;
     }
 }
 
 // 0x487150
-void _movieStop()
-{
+void _movieStop() {
     if (_running) {
         gMovieFlags |= MOVIE_EXTENDED_FLAG_SUBTITLES_LOADED;
     }
 }
 
 // 0x487164
-int movieSetFlags(int flags)
-{
+int movieSetFlags(int flags) {
     // MOVIE_FLAG_0x04 and MOVIE_FLAG_0x02 no longer needed
     // Stripped this down to critical only
     if ((flags & MOVIE_FLAG_ENABLE_SUBTITLES) != 0) {
@@ -509,24 +527,22 @@ int movieSetFlags(int flags)
     return 0;
 }
 
-
 // 0x48725C
-void _movieSetPaletteFunc(MovieSetPaletteEntriesProc* proc)
-{
-    gMovieSetPaletteEntriesProc = proc != nullptr ? proc : _setSystemPaletteEntries;
+void _movieSetPaletteFunc(MovieSetPaletteEntriesProc *proc) {
+    gMovieSetPaletteEntriesProc =
+        proc != nullptr ? proc : _setSystemPaletteEntries;
 }
 
 // 0x487274
-void movieSetPaletteProc(MovieSetPaletteProc* proc)
-{
+void movieSetPaletteProc(MovieSetPaletteProc *proc) {
     gMoviePaletteProc = proc;
 }
 
 // 0x4872E8
-static void _cleanupLast()
-{
+static void _cleanupLast() {
     if (_lastMovieBuffer != nullptr) {
-        internal_free_safe(_lastMovieBuffer, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 981
+        internal_free_safe(_lastMovieBuffer, __FILE__,
+                           __LINE__); // "..\\int\\MOVIE.C", 981
         _lastMovieBuffer = nullptr;
     }
 
@@ -534,8 +550,7 @@ static void _cleanupLast()
 }
 
 // 0x48731C
-static File* movieOpen(char* filePath)
-{
+static File *movieOpen(char *filePath) {
     gMovieFileStream = fileOpen(filePath, "rb");
     if (gMovieFileStream == nullptr) {
         debugPrint("Couldn't find movie file %s\n", filePath);
@@ -545,8 +560,7 @@ static File* movieOpen(char* filePath)
 }
 
 // 0x487380
-static void movieLoadSubtitles(char* filePath)
-{
+static void movieLoadSubtitles(char *filePath) {
     _subtitleW = windowGetWidth(gMovieWindow);
     _subtitleH = fontGetLineHeight() + 4;
 
@@ -558,16 +572,16 @@ static void movieLoadSubtitles(char* filePath)
     strcpy(path, filePath);
 
     debugPrint("Opening subtitle file %s\n", path);
-    File* stream = fileOpen(path, "r");
+    File *stream = fileOpen(path, "r");
     if (stream == nullptr) {
         debugPrint("Couldn't open subtitle file %s\n", path);
         gMovieFlags &= ~MOVIE_EXTENDED_FLAG_SUBTITLES_ENABLED;
         return;
     }
-    
+
     _movieHasSubtitles = true;
-    
-    MovieSubtitleListNode* prev = nullptr;
+
+    MovieSubtitleListNode *prev = nullptr;
     int subtitleCount = 0;
     while (!fileEof(stream)) {
         char string[260];
@@ -577,12 +591,15 @@ static void movieLoadSubtitles(char* filePath)
             break;
         }
 
-        MovieSubtitleListNode* subtitle = (MovieSubtitleListNode*)internal_malloc_safe(sizeof(*subtitle), __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1050
+        MovieSubtitleListNode *subtitle =
+            (MovieSubtitleListNode *)internal_malloc_safe(
+                sizeof(*subtitle), __FILE__,
+                __LINE__); // "..\\int\\MOVIE.C", 1050
         subtitle->next = nullptr;
 
         subtitleCount++;
 
-        char* pch;
+        char *pch;
 
         pch = strchr(string, '\n');
         if (pch != nullptr) {
@@ -598,7 +615,8 @@ static void movieLoadSubtitles(char* filePath)
         if (pch != nullptr) {
             *pch = '\0';
             subtitle->num = atoi(string);
-            subtitle->text = strdup_safe(pch + 1, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1058
+            subtitle->text = strdup_safe(pch + 1, __FILE__,
+                                         __LINE__); // "..\\int\\MOVIE.C", 1058
 
             if (prev != nullptr) {
                 prev->next = subtitle;
@@ -618,8 +636,7 @@ static void movieLoadSubtitles(char* filePath)
 }
 
 // 0x48755C
-static void movieRenderSubtitles()
-{
+static void movieRenderSubtitles() {
     if (gMovieSubtitleHead == nullptr) {
         return;
     }
@@ -638,8 +655,12 @@ static void movieRenderSubtitles()
     // Total subtitle box height
     int subtitleHeight = _subtitleH;
 
-    // Figure out Y position: place subtitle box centered in space below the video
-    int subtitleY = _lastMovieY + _lastMovieH + ((screenGetHeight() - (_lastMovieY + _lastMovieH)) - subtitleHeight) / 2;
+    // Figure out Y position: place subtitle box centered in space below the
+    // video
+    int subtitleY =
+        _lastMovieY + _lastMovieH +
+        ((screenGetHeight() - (_lastMovieY + _lastMovieH)) - subtitleHeight) /
+            2;
 
     // If the subtitle box would go off-screen, nudge it up
     if (subtitleY + subtitleHeight > screenGetHeight()) {
@@ -656,7 +677,7 @@ static void movieRenderSubtitles()
             break;
         }
 
-        MovieSubtitleListNode* next = gMovieSubtitleHead->next;
+        MovieSubtitleListNode *next = gMovieSubtitleHead->next;
 
         // Clear the subtitle region before drawing
         windowFill(gMovieWindow, 0, subtitleY, _subtitleW, subtitleHeight, 0);
@@ -667,18 +688,14 @@ static void movieRenderSubtitles()
             fontSetCurrent(gMovieSubtitlesFont);
         }
 
-        int colorIndex = (gMovieSubtitlesColorR << 10) | (gMovieSubtitlesColorG << 5) | gMovieSubtitlesColorB;
+        int colorIndex = (gMovieSubtitlesColorR << 10) |
+                         (gMovieSubtitlesColorG << 5) | gMovieSubtitlesColorB;
 
         // Render subtitle text, centered within the subtitle box
-        _windowWrapLine(
-            gMovieWindow,
-            gMovieSubtitleHead->text,
-            _subtitleW,
-            subtitleHeight,
-            0,
-            subtitleY,
-            _colorTable[colorIndex] | 0x2000000,
-            TEXT_ALIGNMENT_CENTER);
+        _windowWrapLine(gMovieWindow, gMovieSubtitleHead->text, _subtitleW,
+                        subtitleHeight, 0, subtitleY,
+                        _colorTable[colorIndex] | 0x2000000,
+                        TEXT_ALIGNMENT_CENTER);
 
         // Refresh the window region to make subtitle visible
         Rect subtitleRect;
@@ -699,16 +716,14 @@ static void movieRenderSubtitles()
     }
 }
 
-
 // 0x487710
-static int _movieStart(int win, char* filePath)
-{
+static int _movieStart(int win, char *filePath) {
     if (_running) {
         return 1;
     }
 
     _cleanupLast();
-    
+
     _movieHasSubtitles = false; // reset has subtitles flag
 
     gMovieFileStream = movieOpen(filePath);
@@ -727,9 +742,11 @@ static int _movieStart(int win, char* filePath)
     // Always use direct rendering
     debugPrint("Direct ");
     windowGetRect(gMovieWindow, &gMovieWindowRect);
-    debugPrint("Playing at (%d, %d)  ", _movieX + gMovieWindowRect.left, _movieY + gMovieWindowRect.top);
+    debugPrint("Playing at (%d, %d)  ", _movieX + gMovieWindowRect.left,
+               _movieY + gMovieWindowRect.top);
     MveSetShowFrame(movieDirectImpl);
-    MVE_rmPrepMovie(gMovieFileStream, _movieX + gMovieWindowRect.left, _movieY + gMovieWindowRect.top, 0);
+    MVE_rmPrepMovie(gMovieFileStream, _movieX + gMovieWindowRect.left,
+                    _movieY + gMovieWindowRect.top, 0);
 
     if (_alphaHandle != nullptr) {
         int size;
@@ -739,16 +756,16 @@ static int _movieStart(int win, char* filePath)
         fileReadInt16(_alphaHandle, &tmp);
         fileReadInt16(_alphaHandle, &tmp);
 
-        _alphaBuf = (unsigned char*)internal_malloc_safe(size, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1178
-        _alphaWindowBuf = (unsigned char*)internal_malloc_safe(_movieH * _movieW, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1179
+        _alphaBuf = (unsigned char *)internal_malloc_safe(
+            size, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1178
+        _alphaWindowBuf = (unsigned char *)internal_malloc_safe(
+            _movieH * _movieW, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 1179
 
-        unsigned char* windowBuffer = windowGetBuffer(gMovieWindow);
-        blitBufferToBuffer(windowBuffer + windowGetWidth(gMovieWindow) * _movieY + _movieX,
-            _movieW,
-            _movieH,
-            windowGetWidth(gMovieWindow),
-            _alphaWindowBuf,
-            _movieW);
+        unsigned char *windowBuffer = windowGetBuffer(gMovieWindow);
+        blitBufferToBuffer(windowBuffer +
+                               windowGetWidth(gMovieWindow) * _movieY + _movieX,
+                           _movieW, _movieH, windowGetWidth(gMovieWindow),
+                           _alphaWindowBuf, _movieW);
     }
 
     _movieRect.left = _movieX;
@@ -760,8 +777,7 @@ static int _movieStart(int win, char* filePath)
 }
 
 // 0x487964
-static bool _localMovieCallback()
-{
+static bool _localMovieCallback() {
     movieRenderSubtitles();
 
     if (_movieCallback != nullptr) {
@@ -772,8 +788,7 @@ static bool _localMovieCallback()
 }
 
 // 0x487AC8
-int _movieRun(int win, char* filePath)
-{
+int _movieRun(int win, char *filePath) {
     if (_running) {
         return 1;
     }
@@ -788,8 +803,7 @@ int _movieRun(int win, char* filePath)
 }
 
 // 0x487B1C
-int _movieRunRect(int win, char* filePath, int a3, int a4, int a5, int a6)
-{
+int _movieRunRect(int win, char *filePath, int a3, int a4, int a5, int a6) {
     if (_running) {
         return 1;
     }
@@ -805,8 +819,7 @@ int _movieRunRect(int win, char* filePath, int a3, int a4, int a5, int a6)
 }
 
 // 0x487B7C
-static int _stepMovie()
-{
+static int _stepMovie() {
     if (_alphaHandle != nullptr) {
         int size;
         fileReadInt32(_alphaHandle, &size);
@@ -822,21 +835,18 @@ static int _stepMovie()
 }
 
 // 0x487BC8
-void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc* proc)
-{
+void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc *proc) {
     gMovieBuildSubtitleFilePathProc = proc;
 }
 
 // 0x487BD0
-void movieSetVolume(int volume)
-{
+void movieSetVolume(int volume) {
     int normalizedVolume = _soundVolumeHMItoDirectSound(volume);
     MveSetVolume(normalizedVolume);
 }
 
 // 0x487BEC
-void _movieUpdate()
-{
+void _movieUpdate() {
     if (!_running) {
         return;
     }
@@ -867,9 +877,6 @@ void _movieUpdate()
 }
 
 // 0x487C88
-int _moviePlaying()
-{
-    return _running;
-}
+int _moviePlaying() { return _running; }
 
 } // namespace fallout

--- a/src/movie.h
+++ b/src/movie.h
@@ -6,24 +6,18 @@
 namespace fallout {
 
 typedef enum MovieFlags {
-    MOVIE_FLAG_0x01 = 0x01,
-    MOVIE_FLAG_0x02 = 0x02,
-    MOVIE_FLAG_0x04 = 0x04,
-    MOVIE_FLAG_0x08 = 0x08,
+    MOVIE_FLAG_ENABLE_SUBTITLES    = 0x08, // triggers subtitle loading
 } MovieFlags;
 
 typedef enum MovieExtendedFlags {
-    MOVIE_EXTENDED_FLAG_0x01 = 0x01,
-    MOVIE_EXTENDED_FLAG_0x02 = 0x02,
-    MOVIE_EXTENDED_FLAG_0x04 = 0x04,
-    MOVIE_EXTENDED_FLAG_0x08 = 0x08,
-    MOVIE_EXTENDED_FLAG_0x10 = 0x10,
+    MOVIE_EXTENDED_FLAG_PLAYING              = 0x01, // marks that a movie is currently playing (?)
+    MOVIE_EXTENDED_FLAG_SUBTITLES_LOADED     = 0x02, // internal state: subtitles were loaded
+    MOVIE_EXTENDED_FLAG_SUBTITLES_ENABLED    = 0x10, // external request: subtitles should be loaded
 } MovieExtendedFlags;
 
 typedef char* MovieBuildSubtitleFilePathProc(char* movieFilePath);
 typedef void MovieSetPaletteEntriesProc(unsigned char* palette, int start, int end);
 typedef void MovieSetPaletteProc(int frame);
-typedef int(MovieBlitFunc)(int win, unsigned char* data, int width, int height, int pitch);
 
 void movieInit();
 void movieExit();
@@ -37,6 +31,9 @@ void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc* proc);
 void movieSetVolume(int volume);
 void _movieUpdate();
 int _moviePlaying();
+
+void readMovieSettings();
+int movieGetSizeFlag();
 
 } // namespace fallout
 

--- a/src/movie.h
+++ b/src/movie.h
@@ -6,28 +6,32 @@
 namespace fallout {
 
 typedef enum MovieFlags {
-    MOVIE_FLAG_ENABLE_SUBTITLES    = 0x08, // triggers subtitle loading
+    MOVIE_FLAG_ENABLE_SUBTITLES = 0x08, // triggers subtitle loading
 } MovieFlags;
 
 typedef enum MovieExtendedFlags {
-    MOVIE_EXTENDED_FLAG_PLAYING              = 0x01, // marks that a movie is currently playing (?)
-    MOVIE_EXTENDED_FLAG_SUBTITLES_LOADED     = 0x02, // internal state: subtitles were loaded
-    MOVIE_EXTENDED_FLAG_SUBTITLES_ENABLED    = 0x10, // external request: subtitles should be loaded
+    MOVIE_EXTENDED_FLAG_PLAYING =
+        0x01, // marks that a movie is currently playing (?)
+    MOVIE_EXTENDED_FLAG_SUBTITLES_LOADED =
+        0x02, // internal state: subtitles were loaded
+    MOVIE_EXTENDED_FLAG_SUBTITLES_ENABLED =
+        0x10, // external request: subtitles should be loaded
 } MovieExtendedFlags;
 
-typedef char* MovieBuildSubtitleFilePathProc(char* movieFilePath);
-typedef void MovieSetPaletteEntriesProc(unsigned char* palette, int start, int end);
+typedef char *MovieBuildSubtitleFilePathProc(char *movieFilePath);
+typedef void MovieSetPaletteEntriesProc(unsigned char *palette, int start,
+                                        int end);
 typedef void MovieSetPaletteProc(int frame);
 
 void movieInit();
 void movieExit();
 void _movieStop();
 int movieSetFlags(int a1);
-void _movieSetPaletteFunc(MovieSetPaletteEntriesProc* proc);
-void movieSetPaletteProc(MovieSetPaletteProc* proc);
-int _movieRun(int win, char* filePath);
-int _movieRunRect(int win, char* filePath, int a3, int a4, int a5, int a6);
-void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc* proc);
+void _movieSetPaletteFunc(MovieSetPaletteEntriesProc *proc);
+void movieSetPaletteProc(MovieSetPaletteProc *proc);
+int _movieRun(int win, char *filePath);
+int _movieRunRect(int win, char *filePath, int a3, int a4, int a5, int a6);
+void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc *proc);
 void movieSetVolume(int volume);
 void _movieUpdate();
 int _moviePlaying();


### PR DESCRIPTION
Added video stretching, with support for aspect ratio mode, fullscreen mode, and subtitle margins in fullscreen mode.

Controlled through f2_res.ini with MOVIE_SIZE. Settings of 0 for default, 1 for aspect ratio, and 2 for fullscreen available. Falls back to default movies if no setting in the ini. Subtitle margins automatically added if subtitles are active, and available for the video, otherwise the video is stretched to fullscreen (only in fullscreen mode)

Removed old and unsed code related to buffering video (no longer needed)
Removed old flags that are no longer needed (related to buffered video)